### PR TITLE
Add Time

### DIFF
--- a/examples/oscillator.ipynb
+++ b/examples/oscillator.ipynb
@@ -23,6 +23,32 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = ipywidgets.Output()\n",
+    "output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let python track the browser's beat (the time will be printed in the cell above)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time = ipytone.Time(output)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -4,7 +4,7 @@
 # Copyright (c) Benoit Bovy.
 # Distributed under the terms of the Modified BSD License.
 
-from .ipytone import Oscillator
+from .ipytone import Oscillator, Time
 from ._version import __version__, version_info
 
 

--- a/ipytone/ipytone.py
+++ b/ipytone/ipytone.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from ipywidgets import Widget
-from traitlets import Unicode, Float, Int, Bool, validate, TraitError
+from traitlets import Unicode, Float, Int, Bool, validate, observe, TraitError
 from ._frontend import module_name, module_version
 
 
@@ -27,3 +27,23 @@ class Oscillator(Widget):
         if proposal['value'] not in ["sine", "square", "sawtooth", "triangle"]:
             raise TraitError("Invalid oscillator type")
         return proposal['value']
+
+
+class Time(Widget):
+    """The time in the browser."""
+   
+    _model_name = Unicode('TimeModel').tag(sync=True)
+    _model_module = Unicode(module_name).tag(sync=True)
+    _model_module_version = Unicode(module_version).tag(sync=True)
+
+    time = Float(0, help="The time in the browser").tag(sync=True)
+
+    def __init__(self, output=None, **kwargs):
+        self.output = output
+        super().__init__(**kwargs)
+
+    @observe('time')
+    def _observe_time(self, change):
+        if self.output is not None:
+            with self.output:
+                print(change['new'])

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -87,3 +87,40 @@ class OscillatorModel extends WidgetModel {
 
   private _osc!: Tone.Oscillator;
 }
+
+
+
+export
+class TimeModel extends WidgetModel {
+  defaults() {
+    return {...super.defaults(),
+      _model_name: TimeModel.model_name,
+      _model_module: TimeModel.model_module,
+      _model_module_version: TimeModel.model_module_version,
+      time: 0
+    };
+  }
+
+  initialize(attributes: any, options: any) {
+    super.initialize(attributes, options);
+
+    Tone.Transport.scheduleRepeat((time) => {
+        this.set('time', time);
+        this.save_changes();
+    }, "4n");
+
+    Tone.Transport.start();
+  }
+
+  static serializers: ISerializers = {
+      ...WidgetModel.serializers,
+      // Add any extra serializers here
+    }
+
+  static model_name = 'TimeModel';
+  static model_module = MODULE_NAME;
+  static model_module_version = MODULE_VERSION;
+  static view_name = null;
+  static view_module = null;
+  static view_module_version = MODULE_VERSION;
+}


### PR DESCRIPTION
When we schedule events from python interactively (for instance when the browser is already playing something), we will need to keep the kernel and the front-end in sync. With this PR the browser sends the time at every beat to python, which can observe the corresponding trait.
When running on localhost, there won't be much delay, but when running e.g. on Binder we will probably have to estimate the delay and try to compensate for it (of course it won't be as interactive).
Happy to hear your thoughts.