### PR TITLE
Transport

### DIFF
--- a/examples/oscillator.ipynb
+++ b/examples/oscillator.ipynb
@@ -207,7 +207,69 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "osc.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Schedule a repeated event along the timeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "osc2 = ipytone.Oscillator()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "osc2.to_destination()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's schedule a callback invoked every eighth note after the first measure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with ipytone.transport.schedule_repeat(\"8n\", \"1m\"):\n",
+    "    osc2.start(\"time\").stop(\"time + 0.1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ipytone.transport.start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ipytone.transport.stop()"
+   ]
   }
  ],
  "metadata": {

--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -9,6 +9,7 @@ from .core import Gain, Param, get_destination
 from .graph import get_audio_graph
 from .signal import Abs, Add, GreaterThan, Multiply, Negate, Pow, Signal, Subtract
 from .source import Noise, Oscillator
+from .transport import transport
 
 
 def _jupyter_labextension_paths():

--- a/ipytone/source.py
+++ b/ipytone/source.py
@@ -6,6 +6,7 @@ from traitlets import Bool, Enum, Float, Instance, TraitError, Unicode, validate
 from .base import AudioNode
 from .core import InternalAudioNode
 from .signal import Signal
+from .transport import transport
 
 
 class Source(AudioNode):
@@ -22,20 +23,30 @@ class Source(AudioNode):
         kwargs.update({"_output": out_node})
         super().__init__(*args, **kwargs)
 
-    def start(self):
+    def start(self, time=""):
         """Start the audio source.
 
         If it's already started, this will stop and restart the source.
         """
-        self.state = "started"
+        if transport._is_scheduling:
+            transport._audio_nodes = transport._audio_nodes + [self]
+            transport._methods = transport._methods + ["start"]
+            transport._packed_args = transport._packed_args + [time + " *** "]
+        else:
+            self.state = "started"
 
         return self
 
-    def stop(self):
+    def stop(self, time=""):
         """Stop the audio source."""
 
-        if self.state == "started":
-            self.state = "stopped"
+        if transport._is_scheduling:
+            transport._audio_nodes = transport._audio_nodes + [self]
+            transport._methods = transport._methods + ["stop"]
+            transport._packed_args = transport._packed_args + [time + " *** "]
+        else:
+            if self.state == "started":
+                self.state = "stopped"
 
         return self
 

--- a/ipytone/transport.py
+++ b/ipytone/transport.py
@@ -1,0 +1,59 @@
+import contextlib
+
+from ipywidgets import Widget, widget_serialization
+from traitlets import Bool, Enum, Instance, List, Unicode
+
+from .base import ToneWidgetBase
+
+
+class Transport(ToneWidgetBase):
+    """Transport for timing musical events."""
+
+    _singleton = None
+
+    _model_name = Unicode("TransportModel").tag(sync=True)
+
+    _schedule_op = Unicode().tag(sync=True)
+    _audio_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
+    _methods = List(Unicode()).tag(sync=True)
+    _packed_args = List(Unicode()).tag(sync=True)
+    _toggle_schedule = Bool().tag(sync=True)
+
+    _interval = Unicode().tag(sync=True)
+    _start_time = Unicode().tag(sync=True)
+    _duration = Unicode(allow_none=True).tag(sync=True)
+
+    state = Enum(["started", "stopped"], allow_none=False, default_value="stopped").tag(sync=True)
+
+    def __new__(cls):
+        if Transport._singleton is None:
+            Transport._singleton = super(Transport, cls).__new__(cls)
+        return Transport._singleton
+
+    def __init__(self, **kwargs):
+        self._is_scheduling = False
+        super(Transport, self).__init__(**kwargs)
+
+    @contextlib.contextmanager
+    def schedule_repeat(self, interval, start_time, duration=None):
+        self._is_scheduling = True
+        self._audio_nodes = []
+        self._methods = []
+        self._packed_args = []
+        yield self
+        self._schedule_op = "scheduleRepeat"
+        self._interval = interval
+        self._start_time = start_time
+        self._duration = duration
+        self._toggle_schedule = not self._toggle_schedule
+        self._is_scheduling = False
+
+    def start(self):
+        self.state = "started"
+
+    def stop(self):
+        if self.state == "started":
+            self.state = "stopped"
+
+
+transport = Transport()

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -6,3 +6,4 @@ export * from './widget_core';
 export * from './widget_graph';
 export * from './widget_signal';
 export * from './widget_source';
+export * from './widget_transport';

--- a/src/widget_transport.ts
+++ b/src/widget_transport.ts
@@ -1,0 +1,85 @@
+import {
+  WidgetModel,
+  ISerializers,
+  unpack_models,
+} from '@jupyter-widgets/base';
+
+import * as tone from 'tone';
+
+import { ToneWidgetModel } from './widget_base';
+
+export class TransportModel extends WidgetModel {
+  defaults(): any {
+    return {
+      ...super.defaults(),
+      _model_name: TransportModel.model_name,
+      _toggle_schedule: false,
+      _schedule_op: '',
+      _audio_nodes: [],
+      _methods: [],
+      _packed_args: [],
+      _interval: '',
+      _start_time: '',
+      _duration: null,
+      state: 'stopped',
+    };
+  }
+
+  static serializers: ISerializers = {
+    ...ToneWidgetModel.serializers,
+    _audio_nodes: { deserialize: unpack_models as any },
+  };
+
+  initialize(attributes: Backbone.ObjectHash, options: any): void {
+    super.initialize(attributes, options);
+
+    this.initEventListeners();
+  }
+
+  initEventListeners(): void {
+    this.on('change:state', this.startStopTransport, this);
+    this.on('change:_toggle_schedule', this.schedule, this);
+  }
+
+  private startStopTransport(): void {
+    if (this.get('state') === 'started') {
+      tone.Transport.start();
+    } else {
+      tone.Transport.stop();
+    }
+  }
+
+  private schedule(): void {
+    const schedule_op = this.get('_schedule_op');
+    const audioNodes = this.get('_audio_nodes');
+    const methods = this.get('_methods');
+    const packed_args = this.get('_packed_args');
+    const callback = function (time: number) {
+      for (let i = 0; i < audioNodes.length; i++) {
+        const audioNode = audioNodes[i].node;
+        const method = methods[i];
+        const args = packed_args[i].split(' *** ');
+        args.pop();
+        for (let j = 0; j < args.length; j++) {
+          args[j] = eval(args[j]);
+        }
+        if (method === 'start') {
+          audioNode.start(...args);
+        } else if (method === 'stop') {
+          audioNode.stop(...args);
+        }
+      }
+    };
+    if (schedule_op === 'scheduleRepeat') {
+      const interval = this.get('_interval');
+      const startTime = this.get('_start_time');
+      let duration = this.get('_duration');
+      if (!duration) {
+        duration = Infinity;
+      }
+      tone.Transport.scheduleRepeat(callback, interval, startTime, duration);
+    }
+  }
+
+  static model_name = 'TransportModel';
+}


### PR DESCRIPTION
Since the callback parameter in JavaScript:
```js
Tone.Transport.scheduleRepeat((time) => {
	osc.start(time).stop(time + 0.1);
}, "8n", "1m");
```
doesn't exist in Python, we take the name `time` as a convention. The JS callback becomes a context manager in Python, and is more limited as to what you can execute. Also, the parameters to methods of audio nodes (`start`, `stop`...) must be passed as strings:
```python
with ipytone.transport.schedule_repeat("8n", "1m"):
    osc.start("time").stop("time + 0.1")
```