### PR TITLE
Create widgets on the front-end side for sub nodes

### DIFF
--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -4,10 +4,17 @@
 # Copyright (c) Benoit Bovy.
 # Distributed under the terms of the Modified BSD License.
 
+from ipywidgets import Widget
+
 from ._version import __version__, version_info
 from .core import get_destination
 from .signal import Abs, Add, GreaterThan, Multiply, Negate, Pow, Signal, Subtract
 from .source import Noise, Oscillator
+
+
+# TODO: remove (see https://github.com/jupyter-widgets/ipywidgets/issues/3139)
+_registry = Widget.widget_types
+_registry.register("ipytone", __version__, "SignalModel", "", "", "", Signal)
 
 
 def _jupyter_labextension_paths():

--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -11,7 +11,6 @@ from .core import get_destination
 from .signal import Abs, Add, GreaterThan, Multiply, Negate, Pow, Signal, Subtract
 from .source import Noise, Oscillator
 
-
 # TODO: remove (see https://github.com/jupyter-widgets/ipywidgets/issues/3139)
 _registry = Widget.widget_types
 _registry.register("ipytone", __version__, "SignalModel", "", "", "", Signal)

--- a/ipytone/base.py
+++ b/ipytone/base.py
@@ -1,5 +1,5 @@
 from ipywidgets import Widget, widget_serialization
-from traitlets import Instance, List, Unicode
+from traitlets import Instance, Int, List, Unicode
 
 from ._frontend import module_name, module_version
 
@@ -19,15 +19,25 @@ class AudioNode(ToneWidgetBase):
     _in_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
     _out_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
 
-    def _normalize_destination(self, destination):
-        from .source import Source
+    number_of_inputs = Int(
+        read_only=True,
+        default_value=1,
+        help="The number of inputs feeding into the AudioNode"
+    ).tag(sync=True)
 
+    number_of_outputs = Int(
+        read_only=True,
+        default_value=1,
+        help="The number of outputs of the AudioNode"
+    ).tag(sync=True)
+
+    def _normalize_destination(self, destination):
         if isinstance(destination, AudioNode):
             destination = [destination]
 
         if not all([isinstance(d, AudioNode) for d in destination]):
             raise ValueError("destination(s) must be AudioNode object(s)")
-        if any([isinstance(d, Source) for d in destination]):
+        if any([not d.number_of_inputs for d in destination]):
             raise ValueError("cannot connect to source audio node(s)")
         if self in destination:
             raise ValueError("cannot connect an audio node to itself")

--- a/ipytone/base.py
+++ b/ipytone/base.py
@@ -21,15 +21,11 @@ class AudioNode(ToneWidgetBase):
     _out_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
 
     number_of_inputs = Int(
-        read_only=True,
-        default_value=1,
-        help="The number of inputs feeding into the AudioNode"
+        read_only=True, default_value=1, help="The number of inputs feeding into the AudioNode"
     ).tag(sync=True)
 
     number_of_outputs = Int(
-        read_only=True,
-        default_value=1,
-        help="The number of outputs of the AudioNode"
+        read_only=True, default_value=1, help="The number of outputs of the AudioNode"
     ).tag(sync=True)
 
     def _normalize_destination(self, destination):

--- a/ipytone/base.py
+++ b/ipytone/base.py
@@ -1,5 +1,5 @@
 from ipywidgets import Widget, widget_serialization
-from traitlets import Instance, Int, List, Unicode
+from traitlets import Bool, Instance, Int, List, Unicode
 
 from ._frontend import module_name, module_version
 
@@ -16,6 +16,7 @@ class AudioNode(ToneWidgetBase):
 
     name = Unicode("").tag(sync=True)
 
+    _create_node = Bool(True).tag(sync=True)
     _in_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
     _out_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
 

--- a/ipytone/source.py
+++ b/ipytone/source.py
@@ -1,7 +1,7 @@
 import re
 
 from ipywidgets import widget_serialization
-from traitlets import Bool, Enum, Float, Instance, Int, TraitError, Unicode, validate
+from traitlets import Bool, Enum, Float, Instance, Int, TraitError, Unicode, validate, Union
 
 from .base import AudioNode
 from .signal import Signal
@@ -59,18 +59,14 @@ class Oscillator(Source):
     _model_name = Unicode("OscillatorModel").tag(sync=True)
 
     type = Unicode("sine", help="Oscillator type").tag(sync=True)
-    _frequency = Instance(Signal, allow_none=True).tag(sync=True, **widget_serialization)
-    _detune = Instance(Signal, allow_none=True).tag(sync=True, **widget_serialization)
+    _init_frequency_value = Union([Int(), Float(), Unicode()]).tag(sync=True)
+    _init_detune_value = Float().tag(sync=True)
+    frequency = Instance(Signal, read_only=True, allow_none=True).tag(sync=True, **widget_serialization);
+    detune = Instance(Signal, read_only=True, allow_none=True).tag(sync=True, **widget_serialization);
 
     def __init__(self, type="sine", frequency=440, detune=0, **kwargs):
 
-        if not isinstance(frequency, Signal):
-            frequency = Signal(value=frequency, units="frequency")
-
-        if not isinstance(detune, Signal):
-            detune = Signal(value=detune, units="cents")
-
-        kwargs.update({"type": type, "_frequency": frequency, "_detune": detune})
+        kwargs.update({"type": type, "_init_frequency_value": frequency, "_init_detune_value": detune})
         super().__init__(**kwargs)
 
     @validate("type")
@@ -82,16 +78,6 @@ class Oscillator(Source):
             raise TraitError(f"Invalid oscillator type: {wave}")
 
         return proposal["value"]
-
-    @property
-    def frequency(self) -> Signal:
-        """Oscillator frequency."""
-        return self._frequency
-
-    @property
-    def detune(self) -> Signal:
-        """Oscillator detune."""
-        return self._detune
 
 
 class Noise(Source):

--- a/ipytone/source.py
+++ b/ipytone/source.py
@@ -1,7 +1,7 @@
 import re
 
 from ipywidgets import widget_serialization
-from traitlets import Bool, Enum, Float, Instance, TraitError, Unicode, validate
+from traitlets import Bool, Enum, Float, Instance, Int, TraitError, Unicode, validate
 
 from .base import AudioNode
 from .signal import Signal
@@ -11,6 +11,12 @@ class Source(AudioNode):
     """Audio source node."""
 
     _model_name = Unicode("SourceModel").tag(sync=True)
+
+    number_of_inputs = Int(
+        read_only=True,
+        default_value=0,
+        help="An audio source node has no input"
+    ).tag(sync=True)
 
     mute = Bool(False, help="Mute source").tag(sync=True)
     state = Enum(["started", "stopped"], allow_none=False, default_value="stopped").tag(sync=True)

--- a/ipytone/source.py
+++ b/ipytone/source.py
@@ -1,7 +1,7 @@
 import re
 
 from ipywidgets import widget_serialization
-from traitlets import Bool, Enum, Float, Instance, Int, TraitError, Unicode, validate, Union
+from traitlets import Bool, Enum, Float, Instance, Int, TraitError, Unicode, Union, validate
 
 from .base import AudioNode
 from .signal import Signal
@@ -13,9 +13,7 @@ class Source(AudioNode):
     _model_name = Unicode("SourceModel").tag(sync=True)
 
     number_of_inputs = Int(
-        read_only=True,
-        default_value=0,
-        help="An audio source node has no input"
+        read_only=True, default_value=0, help="An audio source node has no input"
     ).tag(sync=True)
 
     mute = Bool(False, help="Mute source").tag(sync=True)
@@ -61,12 +59,18 @@ class Oscillator(Source):
     type = Unicode("sine", help="Oscillator type").tag(sync=True)
     _init_frequency_value = Union([Int(), Float(), Unicode()]).tag(sync=True)
     _init_detune_value = Float().tag(sync=True)
-    frequency = Instance(Signal, read_only=True, allow_none=True).tag(sync=True, **widget_serialization);
-    detune = Instance(Signal, read_only=True, allow_none=True).tag(sync=True, **widget_serialization);
+    frequency = Instance(Signal, read_only=True, allow_none=True).tag(
+        sync=True, **widget_serialization
+    )
+    detune = Instance(Signal, read_only=True, allow_none=True).tag(
+        sync=True, **widget_serialization
+    )
 
     def __init__(self, type="sine", frequency=440, detune=0, **kwargs):
 
-        kwargs.update({"type": type, "_init_frequency_value": frequency, "_init_detune_value": detune})
+        kwargs.update(
+            {"type": type, "_init_frequency_value": frequency, "_init_detune_value": detune}
+        )
         super().__init__(**kwargs)
 
     @validate("type")

--- a/ipytone/tests/test_source.py
+++ b/ipytone/tests/test_source.py
@@ -25,10 +25,8 @@ def test_oscillator():
     osc = Oscillator()
 
     assert osc.type == "sine"
-    assert osc.frequency.value == 440
-    assert osc.frequency.units == "frequency"
-    assert osc.detune.value == 0
-    assert osc.detune.units == "cents"
+    assert osc._init_frequency_value == 440
+    assert osc._init_detune_value == 0
 
     # just test that the following types are valid
     for wave in ["sine", "square", "sawtooth", "triangle"]:

--- a/src/widget_base.ts
+++ b/src/widget_base.ts
@@ -29,13 +29,22 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
       name: '',
       _in_nodes: [],
       _out_nodes: [],
+      number_of_inputs: 1,
+      number_of_outputs: 1,
     };
   }
 
-  initialize(attributes: Backbone.ObjectHash, options: any): void {
+  initialize(
+    attributes: Backbone.ObjectHash,
+    options: { model_id: string; comm: any; widget_manager: any }
+  ): void {
     super.initialize(attributes, options);
 
     this.node = this.createNode();
+
+    this.set('number_of_inputs', this.node.numberOfInputs);
+    this.set('number_of_outputs', this.node.numberOfOutputs);
+    this.save_changes();
 
     this.initEventListeners();
   }

--- a/src/widget_base.ts
+++ b/src/widget_base.ts
@@ -27,6 +27,7 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
       ...super.defaults(),
       _model_name: AudioNodeModel.model_name,
       name: '',
+      _create_node: false,
       _in_nodes: [],
       _out_nodes: [],
       number_of_inputs: 1,
@@ -40,11 +41,20 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
   ): void {
     super.initialize(attributes, options);
 
-    this.node = this.createNode();
+    // By default, create a Tone node for widgets constructed on the Python side
+    // and do not create a Tone node for widgets constructed on the JS side
+    // (in the latter case, we want to assign an existing Tone node to the new widget).
+    if (this.get('_create_node')) {
+      this.node = this.createNode();
+      this.setModelAttributesFromNode();
+    } else {
+      (this.node as any) = null;
+    }
 
-    this.set('number_of_inputs', this.node.numberOfInputs);
-    this.set('number_of_outputs', this.node.numberOfOutputs);
-    this.save_changes();
+    // create new models for Tone sub-nodes and save this model
+    Promise.all(this.createModels()).then(() => {
+      this.save_changes();
+    });
 
     this.initEventListeners();
   }
@@ -86,13 +96,54 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
     });
   }
 
-  protected connectInputCallback(): void {
+  connectInputCallback(): void {
     /**/
   }
 
   node: tone.ToneAudioNode;
 
   abstract createNode(): tone.ToneAudioNode;
+
+  setModelAttributesFromNode(): void {
+    this.set('number_of_inputs', this.node.numberOfInputs);
+    this.set('number_of_outputs', this.node.numberOfOutputs);
+    this.save_changes();
+  }
+
+  createModels(): Promise<AudioNodeModel>[] {
+    return [];
+  }
+
+  // Create a new instance of a given model class from a given Tone audio node
+  // and assign it to an attribute of this model instance.
+  newModel(
+    model_name: string,
+    attribute_name: string,
+    node: tone.ToneAudioNode
+  ): Promise<AudioNodeModel> {
+    const model: any = this.widget_manager.new_widget({
+      model_name: model_name,
+      model_module: this.get('_model_module'),
+      model_module_version: this.get('_model_module_version'),
+      view_name: '',
+      view_module: '',
+      view_module_version: '',
+    });
+
+    model.then((m: any) => {
+      m.node = node;
+      m.setModelAttributesFromNode();
+      this.set(attribute_name, m);
+      return m;
+    });
+
+    return model;
+  }
+
+  replaceNodeBy(node: tone.ToneAudioNode): void {
+    this.node.dispose();
+    this.node = node;
+  }
 
   static serializers: ISerializers = {
     ...ToneWidgetModel.serializers,

--- a/src/widget_signal.ts
+++ b/src/widget_signal.ts
@@ -30,7 +30,10 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
     };
   }
 
-  initialize(attributes: Backbone.ObjectHash, options: any): void {
+  initialize(
+    attributes: Backbone.ObjectHash,
+    options: { model_id: string; comm: any; widget_manager: any }
+  ): void {
     super.initialize(attributes, options);
 
     this.updateOverridden();

--- a/src/widget_signal.ts
+++ b/src/widget_signal.ts
@@ -22,21 +22,12 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
     return {
       ...super.defaults(),
       _model_name: SignalModel.model_name,
-      value: null,
+      value: 0,
       _units: 'number',
-      _min_value: undefined,
-      _max_value: undefined,
+      _min_value: null,
+      _max_value: null,
       overridden: false,
     };
-  }
-
-  initialize(
-    attributes: Backbone.ObjectHash,
-    options: { model_id: string; comm: any; widget_manager: any }
-  ): void {
-    super.initialize(attributes, options);
-
-    this.updateOverridden();
   }
 
   createNode(): tone.Signal {
@@ -48,6 +39,16 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
     });
   }
 
+  setModelAttributesFromNode(): void {
+    this.set('value', this.node.value);
+    this.set('_units', this.node.units);
+    this.set('_min_value', this.node.minValue);
+    this.set('_max_value', this.node.maxValue);
+    this.set('overridden', this.node.overridden);
+
+    super.setModelAttributesFromNode();
+  }
+
   private updateOverridden(): void {
     this.set('overridden', this.node.overridden);
     // if overridden, value is reset to 0
@@ -55,7 +56,7 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
     this.save_changes();
   }
 
-  protected connectInputCallback(): void {
+  connectInputCallback(): void {
     // new connected incoming signal overrides this signal value
     this.updateOverridden();
   }

--- a/src/widget_source.ts
+++ b/src/widget_source.ts
@@ -1,5 +1,3 @@
-import { ISerializers, unpack_models } from '@jupyter-widgets/base';
-
 import * as tone from 'tone';
 
 // import * as source from 'tone/Tone/source/Source';
@@ -102,12 +100,6 @@ export class OscillatorModel extends SourceModel {
       this.node.type = this.type;
     });
   }
-
-  static serializers: ISerializers = {
-    ...SourceModel.serializers,
-    frequency: { deserialize: unpack_models as any },
-    detune: { deserialize: unpack_models as any },
-  };
 
   node: tone.Oscillator;
 

--- a/src/widget_source.ts
+++ b/src/widget_source.ts
@@ -53,28 +53,34 @@ abstract class SourceModel extends AudioNodeModel {
 
   static model_name = 'SourceModel';
 }
+
 export class OscillatorModel extends SourceModel {
   defaults(): any {
     return {
       ...super.defaults(),
       _model_name: OscillatorModel.model_name,
       type: 'sine',
-      _frequency: null,
-      _detune: null,
+      _init_frequency_value: 440,
+      _init_detune_value: 0,
+      frequency: null,
+      detune: null,
     };
   }
 
   createNode(): tone.Oscillator {
-    const osc = new tone.Oscillator({
+    return new tone.Oscillator({
       type: this.get('type'),
-      volume: this.get('volume'),
+      frequency: this.get('_init_frequency_value'),
+      detune: this.get('_init_detune_value'),
     });
+  }
 
-    // need to bind signals explicitly
-    this.frequency.node.connect(osc.frequency);
-    this.detune.node.connect(osc.detune);
-
-    return osc;
+  createModels(): Promise<AudioNodeModel>[] {
+    return [
+      ...super.createModels(),
+      this.newModel(SignalModel.model_name, 'frequency', this.node.frequency),
+      this.newModel(SignalModel.model_name, 'detune', this.node.detune),
+    ];
   }
 
   get type(): tone.ToneOscillatorType {
@@ -82,11 +88,11 @@ export class OscillatorModel extends SourceModel {
   }
 
   get frequency(): SignalModel<'frequency'> {
-    return this.get('_frequency');
+    return this.get('frequency');
   }
 
   get detune(): SignalModel<'cents'> {
-    return this.get('_detune');
+    return this.get('detune');
   }
 
   initEventListeners(): void {
@@ -99,8 +105,8 @@ export class OscillatorModel extends SourceModel {
 
   static serializers: ISerializers = {
     ...SourceModel.serializers,
-    _frequency: { deserialize: unpack_models as any },
-    _detune: { deserialize: unpack_models as any },
+    frequency: { deserialize: unpack_models as any },
+    detune: { deserialize: unpack_models as any },
   };
 
   node: tone.Oscillator;


### PR DESCRIPTION
Closes #18

This allows to recursively create new widgets on the JS side for Tone.js audio node attributes that are nodes themselves (e.g., `Tone.Oscillator`: `frequency` -> `Tone.Signal` and `detune` -> `Tone.Signal`), so that we can access it from Python.

TODO:

- [ ] figure out if/how we can wait on the Python side for the JS-created widgets to be available.