### PR TITLE
Refactor Input/Output nodes and node connections

### DIFF
--- a/examples/oscillator.ipynb
+++ b/examples/oscillator.ipynb
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The oscillation has now a new output, and the \"destination\" node has it as input."
+    "Let's check the audio graph (no fancy view available yet)."
    ]
   },
   {
@@ -67,7 +67,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "osc.output"
+    "graph = ipytone.get_audio_graph()\n",
+    "\n",
+    "graph.nodes"
    ]
   },
   {
@@ -76,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ipytone.get_destination().input"
+    "graph.connections"
    ]
   },
   {

--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from ._version import __version__, version_info
-from .core import get_destination
+from .core import get_audio_graph, get_destination
 from .signal import Abs, Add, GreaterThan, Multiply, Negate, Pow, Signal, Subtract
 from .source import Noise, Oscillator
 

--- a/ipytone/base.py
+++ b/ipytone/base.py
@@ -1,5 +1,5 @@
 from ipywidgets import Widget, widget_serialization
-from traitlets import Bool, Instance, List, Unicode
+from traitlets import Bool, Instance, Unicode
 
 from ._frontend import module_name, module_version
 
@@ -19,26 +19,11 @@ class AudioNode(ToneWidgetBase):
     _is_internal = False
     _input = Instance(ToneWidgetBase, allow_none=True).tag(sync=True, **widget_serialization)
     _output = Instance(ToneWidgetBase, allow_none=True).tag(sync=True, **widget_serialization)
-
     _create_node = Bool(True).tag(sync=True)
-    _in_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
-    _out_nodes = List(Instance(Widget)).tag(sync=True, **widget_serialization)
-
-    def _normalize_destination(self, destination):
-        if isinstance(destination, AudioNode):
-            destination = [destination]
-
-        if not all([isinstance(d, AudioNode) for d in destination]):
-            raise ValueError("destination(s) must be AudioNode object(s)")
-        if any([not d.number_of_inputs for d in destination]):
-            raise ValueError("cannot connect to source audio node(s)")
-        if self in destination:
-            raise ValueError("cannot connect an audio node to itself")
-
-        return list(set(self._out_nodes) | set(destination))
 
     @property
     def number_of_inputs(self):
+        """Returns the number of input slots for the input node (0 for source nodes)."""
         if self._is_internal:
             return self._n_inputs
         elif self._input is None:
@@ -48,6 +33,7 @@ class AudioNode(ToneWidgetBase):
 
     @property
     def number_of_outputs(self):
+        """Returns the number of output slots for the output node (0 for sink nodes)."""
         if self._is_internal:
             return self._n_outputs
         elif self._output is None:
@@ -56,45 +42,45 @@ class AudioNode(ToneWidgetBase):
             return self._output.number_of_outputs
 
     def connect(self, destination):
-        """Connect the output of this audio node to another ``destination`` audio node."""
+        """Connect the output of this audio node to the input of a ``destination`` audio node."""
 
-        if destination not in self._out_nodes:
-            self._out_nodes = self._normalize_destination(destination)
-            destination._in_nodes = destination._in_nodes + [self]
+        from .core import _AUDIO_GRAPH
+
+        _AUDIO_GRAPH.connect(self, destination)
 
         return self
 
     def disconnect(self, destination):
         """Disconnect the ouput of this audio node from a connected destination."""
 
-        new_out_nodes = list(self._out_nodes)
-        new_out_nodes.remove(destination)
-        self._out_nodes = new_out_nodes
+        from .core import _AUDIO_GRAPH
 
-        new_in_nodes = list(destination._in_nodes)
-        new_in_nodes.remove(self)
-        destination._in_nodes = new_in_nodes
+        _AUDIO_GRAPH.disconnect(self, destination)
 
         return self
 
     def fan(self, *destinations):
         """Connect the output of this audio node to the ``destinations`` audio nodes in parallel."""
 
-        self._out_nodes = self._normalize_destination(destinations)
+        from .core import _AUDIO_GRAPH
 
         for node in destinations:
-            node._in_nodes = node._in_nodes + [self]
+            _AUDIO_GRAPH.connect(self, node, sync=False)
 
+        _AUDIO_GRAPH.sync_connections()
         return self
 
     def chain(self, *nodes):
         """Connect the output of this audio node to the other audio nodes in series."""
 
+        from .core import _AUDIO_GRAPH
+
         chain_nodes = [self] + list(nodes)
 
         for i in range(len(chain_nodes) - 1):
-            chain_nodes[i].connect(chain_nodes[i + 1])
+            _AUDIO_GRAPH.connect(chain_nodes[i], chain_nodes[i + 1], sync=False)
 
+        _AUDIO_GRAPH.sync_connections()
         return self
 
     def to_destination(self):

--- a/ipytone/core.py
+++ b/ipytone/core.py
@@ -1,4 +1,5 @@
-from traitlets import Bool, Float, Int, Unicode
+from ipywidgets import widget_serialization
+from traitlets import Bool, Float, Instance, Int, List, Tuple, Unicode
 
 from .base import AudioNode, ToneWidgetBase
 
@@ -73,3 +74,75 @@ _DESTINATION = Destination()
 def get_destination():
     """Returns ipytone's audio master node."""
     return _DESTINATION
+
+
+class AudioGraph(ToneWidgetBase):
+    """An audio graph representing all nodes and their connections in the main audio context."""
+
+    _model_name = Unicode("AudioGraphModel").tag(sync=True)
+
+    _connections = List(Tuple(Instance(AudioNode), Instance(AudioNode))).tag(
+        sync=True, **widget_serialization
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._updated_connections = list(self._connections)
+
+    def connect(self, src_node, dest_node, sync=True):
+        """Connect a source node output to a destination node input."""
+
+        if not (isinstance(src_node, AudioNode) and isinstance(dest_node, AudioNode)):
+            raise ValueError("Source and destination nodes must be AudioNode objects")
+        if not dest_node.number_of_inputs:
+            raise ValueError(f"Cannot connect to audio source {dest_node}")
+        if not src_node.number_of_outputs:
+            raise ValueError("Cannot connect from an audio sink {src_node}")
+
+        conn = (src_node, dest_node)
+
+        if conn not in self._connections:
+            self._updated_connections.append(conn)
+
+        if sync:
+            self.sync_connections()
+
+    def disconnect(self, src_node, dest_node, sync=True):
+        """Disconnect a source node output from a destination node input."""
+
+        conn = (src_node, dest_node)
+
+        if conn not in self._connections:
+            raise ValueError(f"Node {src_node} is not connected to node {dest_node}")
+
+        self._updated_connections.remove(conn)
+
+        if sync:
+            self.sync_connections()
+
+    def sync_connections(self):
+        """Synchronize connections with the front-end (internal use)."""
+
+        self._connections = self._updated_connections
+        self._updated_connections = self._connections.copy()
+
+    @property
+    def connections(self):
+        """Returns the audio graph edges as a list of (src_node, dest_node) tuples."""
+
+        return list(self._connections)
+
+    @property
+    def nodes(self):
+        """Returns a list of all nodes in the audio graph."""
+
+        return list({node for conn in self._connections for node in conn})
+
+
+_AUDIO_GRAPH = AudioGraph()
+
+
+def get_audio_graph():
+    """Returns the audio graph of ipytone's main audio context."""
+    return _AUDIO_GRAPH

--- a/ipytone/core.py
+++ b/ipytone/core.py
@@ -1,6 +1,45 @@
-from traitlets import Bool, Float, Unicode
+from traitlets import Bool, Float, Int, Unicode
 
-from .base import AudioNode
+from .base import AudioNode, ToneWidgetBase
+
+
+class InternalNode(ToneWidgetBase):
+    """Ipytone Widget that wraps a Tone.js object with no exposed functionality."""
+
+    _model_name = Unicode("InternalNodeModel").tag(sync=True)
+
+    _is_internal = True
+    _n_inputs = Int(1, allow_none=True).tag(sync=True)
+    _n_outputs = Int(1, allow_none=True).tag(sync=True)
+    tone_class = Unicode().tag(sync=True)
+
+    @property
+    def number_of_inputs(self):
+        return self._n_inputs
+
+    @property
+    def number_of_outputs(self):
+        return self._n_outputs
+
+    def _repr_keys(self):
+        if self.tone_class:
+            yield "tone_class"
+
+
+class InternalAudioNode(AudioNode):
+    """Ipytone Widget that wraps a Tone.js audio node instance with no exposed functionality."""
+
+    _model_name = Unicode("InternalAudioNodeModel").tag(sync=True)
+
+    _is_internal = True
+    _n_inputs = Int(1, allow_none=True).tag(sync=True)
+    _n_outputs = Int(1, allow_none=True).tag(sync=True)
+    tone_class = Unicode().tag(sync=True)
+    _create_node = Bool(False).tag(sync=True)
+
+    def _repr_keys(self):
+        if self.tone_class:
+            yield "tone_class"
 
 
 class Destination(AudioNode):
@@ -19,6 +58,13 @@ class Destination(AudioNode):
         if Destination._singleton is None:
             Destination._singleton = super(Destination, cls).__new__(cls)
         return Destination._singleton
+
+    def __init__(self, *args, **kwargs):
+        in_node = InternalAudioNode(tone_class="Gain")
+        out_node = InternalAudioNode(tone_class="Volume")
+
+        kwargs.update({"_input": in_node, "_output": out_node})
+        super().__init__(*args, **kwargs)
 
 
 _DESTINATION = Destination()

--- a/ipytone/core.py
+++ b/ipytone/core.py
@@ -98,7 +98,7 @@ class AudioGraph(ToneWidgetBase):
         if not dest_node.number_of_inputs:
             raise ValueError(f"Cannot connect to audio source {dest_node}")
         if not src_node.number_of_outputs:
-            raise ValueError("Cannot connect from an audio sink {src_node}")
+            raise ValueError(f"Cannot connect from audio sink {src_node}")
 
         conn = (src_node, dest_node)
 

--- a/ipytone/signal.py
+++ b/ipytone/signal.py
@@ -1,8 +1,5 @@
-import warnings
-
 from ipywidgets import widget_serialization
 from traitlets import Bool, Enum, Float, Instance, Int, Unicode, Union
-from traitlets.traitlets import validate
 
 from .base import AudioNode
 from .core import InternalAudioNode, InternalNode
@@ -135,17 +132,6 @@ class Signal(SignalOperator):
     def max_value(self):
         """Signal value upper limit."""
         return self._max_value
-
-    @validate("value")
-    def _validate_value(self, proposal):
-        if self.overridden:
-            warnings.warn(
-                "Signal value overridden by a connected signal, setting its value "
-                "may have not effect.",
-                UserWarning,
-            )
-
-        return proposal["value"]
 
     def _repr_keys(self):
         for key in super()._repr_keys():

--- a/ipytone/signal.py
+++ b/ipytone/signal.py
@@ -262,7 +262,7 @@ class GreaterThan(Signal):
         in_node = InternalAudioNode(tone_class="Substract")
         out_node = InternalAudioNode(tone_class="GreaterThanZero")
 
-        kw = {"_comparator": _as_signal(comparator), "_input": in_node, "output": out_node}
+        kw = {"_comparator": _as_signal(comparator), "_input": in_node, "_output": out_node}
         kwargs.update(kw)
         super().__init__(**kwargs)
 

--- a/ipytone/tests/conftest.py
+++ b/ipytone/tests/conftest.py
@@ -8,6 +8,8 @@ import pytest
 from ipykernel.comm import Comm
 from ipywidgets import Widget
 
+from ipytone import get_audio_graph
+
 
 class MockComm(Comm):
     """A mock Comm object.
@@ -56,3 +58,13 @@ def mock_comm():
             delattr(Widget, attr)
         else:
             setattr(Widget, attr, value)
+
+
+@pytest.fixture
+def audio_graph():
+    audio_graph = get_audio_graph()
+    audio_graph._connections = []
+    audio_graph._updated_connections = []
+    yield audio_graph
+    audio_graph._connections = []
+    audio_graph._updated_connections = []

--- a/ipytone/tests/test_base.py
+++ b/ipytone/tests/test_base.py
@@ -1,82 +1,70 @@
-import pytest
-
 from ipytone.base import AudioNode
-from ipytone.core import get_destination
-from ipytone.source import Source
+from ipytone.core import InternalAudioNode, get_destination
 
 
 def test_audio_node_creation():
     node = AudioNode(name="test")
 
-    assert node.input == []
-    assert node.output == []
+    assert node.input is None
+    assert node.output is None
+    assert node.number_of_inputs == 0
+    assert node.number_of_outputs == 0
     assert repr(node) == "AudioNode(name='test')"
 
 
-def test_audio_node_connect():
-    node1 = AudioNode()
-    node2 = AudioNode()
+def test_audio_node_connect(audio_graph):
+    node1 = InternalAudioNode()
+    node2 = InternalAudioNode()
 
     n = node1.connect(node2)
 
-    assert node1.output == [node2]
-    assert node2.input == [node1]
+    assert (node1, node2) in audio_graph.connections
     assert n is node1
 
     n = node1.disconnect(node2)
 
-    assert node1.output == []
-    assert node2.input == []
+    assert (node1, node2) not in audio_graph.connections
     assert n is node1
 
 
-@pytest.mark.parametrize("func", [AudioNode.connect, AudioNode.fan])
-def test_audio_node_connect_error(func):
-    node1 = AudioNode()
-    src = Source()
+def test_audio_node_disconnect(audio_graph):
+    node1 = InternalAudioNode()
+    node2 = InternalAudioNode()
 
-    with pytest.raises(ValueError, match="cannot connect an audio node to itself"):
-        func(node1, node1)
+    n = node1.connect(node2).disconnect(node2)
 
-    with pytest.raises(ValueError, match="cannot connect to source.*"):
-        func(node1, src)
-
-    with pytest.raises(ValueError, match=".*must be AudioNode.*"):
-        func(node1, "not an audio node")
+    assert (node1, node2) not in audio_graph.connections
+    assert n is node1
 
 
-def test_audio_node_to_destination():
-    node = AudioNode()
+def test_audio_node_to_destination(audio_graph):
+    node = InternalAudioNode()
 
     n = node.to_destination()
 
-    assert node.output == [get_destination()]
-    assert get_destination().input == [node]
+    assert (node, get_destination()) in audio_graph.connections
     assert n is node
 
 
-def test_audio_node_fan():
-    node1 = AudioNode()
-    node2 = AudioNode()
-    node3 = AudioNode()
+def test_audio_node_fan(audio_graph):
+    node1 = InternalAudioNode()
+    node2 = InternalAudioNode()
+    node3 = InternalAudioNode()
 
     n = node1.fan(node2, node3)
 
-    assert set(node1.output) == set([node2, node3])
-    assert node2.input == [node1]
-    assert node3.input == [node1]
+    assert (node1, node2) in audio_graph.connections
+    assert (node1, node3) in audio_graph.connections
     assert n is node1
 
 
-def test_audio_node_chain():
-    node1 = AudioNode()
-    node2 = AudioNode()
-    node3 = AudioNode()
+def test_audio_node_chain(audio_graph):
+    node1 = InternalAudioNode()
+    node2 = InternalAudioNode()
+    node3 = InternalAudioNode()
 
     n = node1.chain(node2, node3)
 
-    assert node1.output == [node2]
-    assert node2.output == [node3]
-    assert node2.input == [node1]
-    assert node3.input == [node2]
+    assert (node1, node2) in audio_graph.connections
+    assert (node2, node3) in audio_graph.connections
     assert n is node1

--- a/ipytone/tests/test_core.py
+++ b/ipytone/tests/test_core.py
@@ -1,5 +1,23 @@
+import pytest
+
 from ipytone import get_destination
-from ipytone.core import Destination
+from ipytone.core import Destination, InternalAudioNode, InternalNode
+
+
+def test_internal_node():
+    node = InternalNode(tone_class="test")
+
+    assert node.number_of_inputs == 1
+    assert node.number_of_outputs == 1
+    assert repr(node) == "InternalNode(tone_class='test')"
+
+
+def test_internal_audio_node():
+    node = InternalAudioNode(tone_class="test")
+
+    assert node.number_of_inputs == 1
+    assert node.number_of_outputs == 1
+    assert repr(node) == "InternalAudioNode(tone_class='test')"
 
 
 def test_destination():
@@ -7,9 +25,46 @@ def test_destination():
 
     assert dest.mute is False
     assert dest.volume == -16
+    assert isinstance(dest.input, InternalAudioNode)
+    assert isinstance(dest.output, InternalAudioNode)
 
     # test singleton
     dest1 = Destination()
     dest2 = Destination()
 
     assert dest1 == dest2 == get_destination()
+
+
+def test_audio_graph(audio_graph):
+    src = InternalAudioNode()
+    dest = InternalAudioNode()
+
+    audio_graph.connect(src, dest, sync=False)
+    assert (src, dest) not in audio_graph.connections
+    audio_graph.sync_connections()
+    assert (src, dest) in audio_graph.connections
+
+    assert audio_graph.nodes == list({src, dest})
+    assert audio_graph.connections == [(src, dest)]
+
+    audio_graph.disconnect(src, dest, sync=False)
+    assert (src, dest) in audio_graph.connections
+    audio_graph.sync_connections()
+    assert (src, dest) not in audio_graph.connections
+
+    with pytest.raises(ValueError, match=".*not connected to.*"):
+        audio_graph.disconnect(src, dest)
+
+    for src, dest in [(src, "not a node"), ("not a node", dest), ("not a node", "not a node")]:
+        with pytest.raises(ValueError, match=".*must be AudioNode objects"):
+            audio_graph.connect(src, dest)
+
+    src = InternalAudioNode()
+    dest = InternalAudioNode(_n_inputs=0)
+    with pytest.raises(ValueError, match="Cannot connect to audio source.*"):
+        audio_graph.connect(src, dest)
+
+    src = InternalAudioNode(_n_outputs=0)
+    dest = InternalAudioNode()
+    with pytest.raises(ValueError, match="Cannot connect from audio sink.*"):
+        audio_graph.connect(src, dest)

--- a/src/widget_base.ts
+++ b/src/widget_base.ts
@@ -57,12 +57,8 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
 
     if (this.get('_create_node')) {
       this.node = this.createNode();
-      if (this.input !== null) {
-        this.input.node = this.node.input;
-      }
-      if (this.output !== null) {
-        this.output.node = this.node.output;
-      }
+      this.setInputOutputNodes();
+      this.setSubNodes();
     }
 
     this.initEventListeners();
@@ -123,6 +119,11 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
 
   setNode(node: tone.ToneAudioNode): void {
     this.node = node;
+    this.setInputOutputNodes();
+    this.setSubNodes();
+  }
+
+  private setInputOutputNodes(): void {
     if (this.input !== null) {
       this.input.node = this.node.input;
     }

--- a/src/widget_base.ts
+++ b/src/widget_base.ts
@@ -17,6 +17,19 @@ export abstract class ToneWidgetModel extends WidgetModel {
     };
   }
 
+  initialize(
+    attributes: Backbone.ObjectHash,
+    options: { model_id: string; comm: any; widget_manager: any }
+  ): void {
+    super.initialize(attributes, options);
+
+    this.initEventListeners();
+  }
+
+  initEventListeners(): void {
+    /**/
+  }
+
   static model_module = MODULE_NAME;
   static model_module_version = MODULE_VERSION;
 }
@@ -47,12 +60,13 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
       _create_node: true,
       _input: null,
       _output: null,
-      _in_nodes: [],
-      _out_nodes: [],
     };
   }
 
-  initialize(attributes: Backbone.ObjectHash, options: any): void {
+  initialize(
+    attributes: Backbone.ObjectHash,
+    options: { model_id: string; comm: any; widget_manager: any }
+  ): void {
     super.initialize(attributes, options);
 
     if (this.get('_create_node')) {
@@ -60,8 +74,6 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
       this.setInputOutputNodes();
       this.setSubNodes();
     }
-
-    this.initEventListeners();
   }
 
   get input(): NodeModel {
@@ -72,44 +84,7 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
     return this.get('_output');
   }
 
-  initEventListeners(): void {
-    this.on('change:_out_nodes', this.updateConnections, this);
-  }
-
-  private getToneAudioNodes(models: AudioNodeModel[]): tone.ToneAudioNode[] {
-    return models.map((model: AudioNodeModel) => {
-      return model.node;
-    });
-  }
-
-  private updateConnections(): void {
-    // connect new nodes (if any)
-    const nodesAdded = this.get('_out_nodes').filter(
-      (other: AudioNodeModel) => {
-        return !this.previous('_out_nodes').includes(other);
-      }
-    );
-
-    this.node.fan(...this.getToneAudioNodes(nodesAdded));
-
-    // disconnect nodes that have been removed (if any)
-    const nodesRemoved = this.previous('_out_nodes').filter(
-      (other: AudioNodeModel) => {
-        return !this.get('_out_nodes').includes(other);
-      }
-    );
-
-    this.getToneAudioNodes(nodesRemoved).forEach((node) => {
-      this.node.disconnect(node);
-    });
-
-    // callbacks of updated destination nodes
-    nodesAdded.concat(nodesRemoved).forEach((model: AudioNodeModel) => {
-      model.connectInputCallback();
-    });
-  }
-
-  protected connectInputCallback(): void {
+  connectInputCallback(): void {
     /**/
   }
 
@@ -140,8 +115,6 @@ export abstract class AudioNodeModel extends ToneWidgetModel {
     ...ToneWidgetModel.serializers,
     _input: { deserialize: unpack_models as any },
     _output: { deserialize: unpack_models as any },
-    _in_nodes: { deserialize: unpack_models as any },
-    _out_nodes: { deserialize: unpack_models as any },
   };
 
   static model_name = 'AudioNodeModel';

--- a/src/widget_core.ts
+++ b/src/widget_core.ts
@@ -1,6 +1,39 @@
 import * as tone from 'tone';
 
-import { AudioNodeModel } from './widget_base';
+import { AudioNodeModel, ToneWidgetModel } from './widget_base';
+
+export class InternalNodeModel extends ToneWidgetModel {
+  defaults(): any {
+    return {
+      ...super.defaults(),
+      _model_name: InternalNodeModel.model_name,
+      _n_inputs: 1,
+      _n_outputs: 1,
+      _tone_class: 'ToneWithContext',
+    };
+  }
+
+  static model_name = 'InternalNodeModel';
+}
+
+export class InternalAudioNodeModel extends AudioNodeModel {
+  defaults(): any {
+    return {
+      ...super.defaults(),
+      _model_name: InternalAudioNodeModel.model_name,
+      _n_inputs: 1,
+      _n_outputs: 1,
+      _tone_class: 'ToneAudioNode',
+      _create_node: false,
+    };
+  }
+
+  createNode(): tone.ToneAudioNode {
+    throw new Error('Not implemented');
+  }
+
+  static model_name = 'InternalAudioNodeModel';
+}
 
 export class DestinationModel extends AudioNodeModel {
   defaults(): any {

--- a/src/widget_core.ts
+++ b/src/widget_core.ts
@@ -1,3 +1,5 @@
+import { ISerializers, unpack_models } from '@jupyter-widgets/base';
+
 import * as tone from 'tone';
 
 import { AudioNodeModel, ToneWidgetModel } from './widget_base';
@@ -71,4 +73,83 @@ export class DestinationModel extends AudioNodeModel {
   node: typeof tone.Destination;
 
   static model_name = 'DestinationModel';
+}
+
+type Connection = [AudioNodeModel, AudioNodeModel];
+type ConnectionNode = [tone.ToneAudioNode, tone.ToneAudioNode];
+
+function getConnectionNodes(connections: Connection[]): ConnectionNode[] {
+  return connections.map((conn: Connection) => {
+    return [conn[0].node, conn[1].node];
+  });
+}
+
+function getConnectionId(conn: Connection): string {
+  return conn[0].model_id + '::' + conn[1].model_id;
+}
+
+function getConnectionIds(connections: Connection[]): string[] {
+  return connections.map((conn: Connection) => {
+    return getConnectionId(conn);
+  });
+}
+
+export class AudioGraphModel extends ToneWidgetModel {
+  defaults(): any {
+    return {
+      ...super.defaults(),
+      _model_name: AudioGraphModel.model_name,
+      _connections: [],
+    };
+  }
+
+  get connections(): Connection[] {
+    return this.get('_connections');
+  }
+
+  get connections_prev(): Connection[] {
+    return this.previous('_connections');
+  }
+
+  private updateConnections(): void {
+    // connect nodes for new connections
+    const connAdded = this.connections.filter((other: Connection) => {
+      const other_id: string = getConnectionId(other);
+      const prev_ids = getConnectionIds(this.connections_prev);
+      return !prev_ids.includes(other_id);
+    });
+
+    getConnectionNodes(connAdded).forEach((conn_node) => {
+      conn_node[0].connect(conn_node[1]);
+    });
+
+    // disconnect nodes for removed connections
+    const connRemoved = this.connections_prev.filter((other: Connection) => {
+      const other_id: string = getConnectionId(other);
+      const current_ids = getConnectionIds(this.connections_prev);
+      return !current_ids.includes(other_id);
+    });
+
+    getConnectionNodes(connRemoved).forEach((conn_node) => {
+      conn_node[0].disconnect(conn_node[1]);
+    });
+
+    // callbacks of updated destination nodes
+    connAdded.concat(connRemoved).forEach((conn: Connection) => {
+      conn[1].connectInputCallback();
+    });
+  }
+
+  initEventListeners(): void {
+    super.initEventListeners();
+
+    this.on('change:_connections', this.updateConnections, this);
+  }
+
+  static serializers: ISerializers = {
+    ...ToneWidgetModel.serializers,
+    _connections: { deserialize: unpack_models as any },
+  };
+
+  static model_name = 'AudioGraphModel';
 }

--- a/src/widget_signal.ts
+++ b/src/widget_signal.ts
@@ -22,7 +22,7 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
     return {
       ...super.defaults(),
       _model_name: SignalModel.model_name,
-      value: null,
+      value: 0,
       _units: 'number',
       _min_value: undefined,
       _max_value: undefined,
@@ -33,7 +33,9 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
   initialize(attributes: Backbone.ObjectHash, options: any): void {
     super.initialize(attributes, options);
 
-    this.updateOverridden();
+    if (this.get('_create_node')) {
+      this.updateOverridden();
+    }
   }
 
   createNode(): tone.Signal {

--- a/src/widget_signal.ts
+++ b/src/widget_signal.ts
@@ -30,7 +30,10 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
     };
   }
 
-  initialize(attributes: Backbone.ObjectHash, options: any): void {
+  initialize(
+    attributes: Backbone.ObjectHash,
+    options: { model_id: string; comm: any; widget_manager: any }
+  ): void {
     super.initialize(attributes, options);
 
     if (this.get('_create_node')) {
@@ -54,7 +57,7 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
     this.save_changes();
   }
 
-  protected connectInputCallback(): void {
+  connectInputCallback(): void {
     // new connected incoming signal overrides this signal value
     this.updateOverridden();
   }

--- a/src/widget_source.ts
+++ b/src/widget_source.ts
@@ -65,18 +65,17 @@ export class OscillatorModel extends SourceModel {
   }
 
   createNode(): tone.Oscillator {
-    const osc = new tone.Oscillator({
+    return new tone.Oscillator({
       type: this.get('type'),
       frequency: this.get('_frequency').get('value'),
       detune: this.get('_detune').get('value'),
       volume: this.get('volume'),
     });
+  }
 
-    // assign sub-nodes
-    this.frequency.node = osc.frequency;
-    this.detune.node = osc.detune;
-
-    return osc;
+  setSubNodes(): void {
+    this.frequency.setNode(this.node.frequency);
+    this.detune.setNode(this.node.detune);
   }
 
   get type(): tone.ToneOscillatorType {

--- a/src/widget_source.ts
+++ b/src/widget_source.ts
@@ -67,12 +67,14 @@ export class OscillatorModel extends SourceModel {
   createNode(): tone.Oscillator {
     const osc = new tone.Oscillator({
       type: this.get('type'),
+      frequency: this.get('_frequency').get('value'),
+      detune: this.get('_detune').get('value'),
       volume: this.get('volume'),
     });
 
-    // need to bind signals explicitly
-    this.frequency.node.connect(osc.frequency);
-    this.detune.node.connect(osc.detune);
+    // assign sub-nodes
+    this.frequency.node = osc.frequency;
+    this.detune.node = osc.detune;
 
     return osc;
   }


### PR DESCRIPTION
This PR makes audio node input / output properties more consistent with Tone.js.

In Tone.js, a `ToneAudioNode` instance may have cascading `input` and `output` nodes until web audio API nodes are found. As in `ipytone` not all nodes are available (yet) as widgets, this PR defines `InternalNode` and `InternalAudioNode` widgets as input/output end-points.

When creating a new audio node, new widget instances are created on the Python side for the input and output nodes just before creating the audio node widget (in `__init__`), so that we can then assign the Tone.js input/output nodes to their corresponding widgets on the JS side just after creating and/or setting a Tone.js node to the widget. 

TODO:

- [x] Add an `AudioGraph` widget in ipytone to manage and track node connections from Python.
- Support multiple-slots for node input/output (in later PR)

