### PR TITLE
Revisit transport scheduling callbacks

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,5 +11,6 @@ dependencies:
   - numpy
   - pip
   - pytest
+  - pytest-mock
   - traittypes
   - yarn

--- a/examples/oscillator.ipynb
+++ b/examples/oscillator.ipynb
@@ -249,8 +249,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with ipytone.transport.schedule_repeat(\"8n\", \"1m\") as event_id:\n",
-    "    osc2.start(\"time\").stop(\"time + 0.1\")"
+    "def callback(time):\n",
+    "    osc2.start(time).stop(time + 0.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "event_id = ipytone.transport.schedule_repeat(callback, \"8n\", \"1m\")"
    ]
   },
   {
@@ -307,8 +316,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with ipytone.transport.schedule(\"1m\") as event_id:\n",
-    "    osc2.start(\"time\").stop(\"time + 0.1\")"
+    "event_id = ipytone.transport.schedule(callback, \"1m\")"
    ]
   },
   {
@@ -390,8 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with ipytone.transport.schedule_once(\"1m\") as event_id:\n",
-    "    osc2.start(\"time\").stop(\"time + 0.1\")"
+    "ipytone.transport.schedule_once(callback, \"1m\")"
    ]
   },
   {
@@ -434,6 +441,13 @@
    "source": [
     "ipytone.transport.start()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -12,7 +12,7 @@ from .envelope import AmplitudeEnvelope, Envelope, FrequencyEnvelope
 from .graph import get_audio_graph
 from .signal import Abs, Add, GreaterThan, Multiply, Negate, Pow, Scale, Signal, Subtract
 from .source import Noise, Oscillator, Player, Players
-from .transport import transport
+from .transport import schedule, schedule_once, schedule_repeat, transport
 
 
 def _jupyter_labextension_paths():

--- a/ipytone/effect.py
+++ b/ipytone/effect.py
@@ -5,7 +5,7 @@ from .base import AudioNode
 from .channel import CrossFade
 from .core import Gain, Param
 from .signal import Signal
-from .transport import start_node, stop_node
+from .transport import add_or_send_event
 from .utils import validate_osc_type
 
 
@@ -191,17 +191,19 @@ class Tremolo(StereoEffect):
         """Tremolo depth."""
         return self._depth
 
-    def start(self, time=""):
+    def start(self, time=None):
         """Start the tremolo effect.
 
         If it's already started, this will stop and restart the source.
         """
-        return start_node(self, time=time)
+        add_or_send_event("start", self, {"time": time})
+        return self
 
-    def stop(self, time=""):
+    def stop(self, time=None):
         """Stop the tremolo effect."""
 
-        return stop_node(self, time=time)
+        add_or_send_event("stop", self, {"time": time})
+        return self
 
     def dispose(self):
         with self._graph.hold_state():

--- a/ipytone/effect.py
+++ b/ipytone/effect.py
@@ -164,7 +164,6 @@ class Tremolo(StereoEffect):
 
     type = Unicode("sine", help="Tremolo LFO type").tag(sync=True)
     spread = Float(180, help="Tremolo stereo spread (degrees)").tag(sync=True)
-    state = Enum(["started", "stopped"], allow_none=False, default_value="stopped").tag(sync=True)
     _frequency = Instance(Signal).tag(sync=True, **widget_serialization)
     _depth = Instance(Signal).tag(sync=True, **widget_serialization)
 

--- a/ipytone/envelope.py
+++ b/ipytone/envelope.py
@@ -5,7 +5,7 @@ from .base import AudioNode
 from .core import Gain
 from .serialization import data_array_serialization
 from .signal import Pow, Scale, Signal
-from .transport import BaseCallbackArg
+from .transport import add_or_send_event
 
 BASIC_CURVES = ["linear", "exponential"]
 CURVES = BASIC_CURVES + ["sine", "cosine", "bounce", "ripple", "step"]
@@ -42,26 +42,17 @@ class Envelope(AudioNode):
 
         super().__init__(**kwargs)
 
-    def trigger_attack(self, time=""):
-        self.send({"event": "triggerAttack"})
+    def trigger_attack(self, time=None, velocity=1):
+        add_or_send_event("triggerAttack", self, {"time": time, "velocity": velocity})
         return self
 
-    def trigger_release(self, time=""):
-        self.send({"event": "triggerRelease"})
+    def trigger_release(self, time=None):
+        add_or_send_event("triggerRelease", self, {"time": time})
         return self
 
-    def trigger_attack_release(self, duration, time="", velocity=1):
-        event_args = {"event": "triggerAttackRelease", "duration": duration, "schedule": False}
-        if isinstance(time, BaseCallbackArg):
-            item = {
-                "method": "triggerAttackRelease",
-                "callee": self.model_id,
-                "args": {"duration": duration, "time": time.value, "velocity": velocity},
-                "arg_keys": ["duration", "time", "velocity"],
-            }
-            time.items.append(item)
-        else:
-            self.send(event_args)
+    def trigger_attack_release(self, duration, time=None, velocity=1):
+        args = {"duration": duration, "time": time, "velocity": velocity}
+        add_or_send_event("triggerAttackRelease", self, args)
         return self
 
     def _repr_keys(self):

--- a/ipytone/envelope.py
+++ b/ipytone/envelope.py
@@ -5,6 +5,7 @@ from .base import AudioNode
 from .core import Gain
 from .serialization import data_array_serialization
 from .signal import Pow, Scale, Signal
+from .transport import BaseCallbackArg
 
 BASIC_CURVES = ["linear", "exponential"]
 CURVES = BASIC_CURVES + ["sine", "cosine", "bounce", "ripple", "step"]
@@ -50,7 +51,16 @@ class Envelope(AudioNode):
         return self
 
     def trigger_attack_release(self, duration, time=""):
-        self.send({"event": "triggerAttackRelease", "duration": duration})
+        event_args = {"event": "triggerAttackRelease", "duration": duration, "schedule": False}
+        if isinstance(time, BaseCallbackArg):
+            extra_args = {
+                "schedule": True,
+                "time": time.value,
+                "call_id": time.call_id,
+                "caller_widget": time.caller_widget.model_id,
+            }
+            event_args.update(extra_args)
+        self.send(event_args)
         return self
 
     def _repr_keys(self):

--- a/ipytone/envelope.py
+++ b/ipytone/envelope.py
@@ -50,17 +50,18 @@ class Envelope(AudioNode):
         self.send({"event": "triggerRelease"})
         return self
 
-    def trigger_attack_release(self, duration, time=""):
+    def trigger_attack_release(self, duration, time="", velocity=1):
         event_args = {"event": "triggerAttackRelease", "duration": duration, "schedule": False}
         if isinstance(time, BaseCallbackArg):
-            extra_args = {
-                "schedule": True,
-                "time": time.value,
-                "call_id": time.call_id,
-                "caller_widget": time.caller_widget.model_id,
+            item = {
+                "method": "triggerAttackRelease",
+                "callee": self.model_id,
+                "args": {"duration": duration, "time": time.value, "velocity": velocity},
+                "arg_keys": ["duration", "time", "velocity"],
             }
-            event_args.update(extra_args)
-        self.send(event_args)
+            time.items.append(item)
+        else:
+            self.send(event_args)
         return self
 
     def _repr_keys(self):

--- a/ipytone/source.py
+++ b/ipytone/source.py
@@ -14,7 +14,6 @@ class Source(AudioNode):
     _model_name = Unicode("SourceModel").tag(sync=True)
 
     mute = Bool(False, help="Mute source").tag(sync=True)
-    state = Enum(["started", "stopped"], allow_none=False, default_value="stopped").tag(sync=True)
     _volume = Instance(Param).tag(sync=True, **widget_serialization)
 
     def __init__(self, volume=0, mute=False, **kwargs):

--- a/ipytone/source.py
+++ b/ipytone/source.py
@@ -4,7 +4,7 @@ from traitlets import Bool, Enum, Float, Instance, TraitError, Unicode, validate
 from .base import AudioNode
 from .core import AudioBuffer, AudioBuffers, Param, Volume
 from .signal import Signal
-from .transport import start_node, stop_node
+from .transport import add_or_send_event
 from .utils import validate_osc_type
 
 
@@ -27,17 +27,18 @@ class Source(AudioNode):
         """The volume parameter."""
         return self._volume
 
-    def start(self, time=""):
+    def start(self, time=None, offset=None, duration=None):
         """Start the audio source.
 
         If it's already started, this will stop and restart the source.
         """
-        return start_node(self, time=time)
+        add_or_send_event("start", self, {"time": time, "offset": offset, "duration": duration})
+        return self
 
-    def stop(self, time=""):
+    def stop(self, time=None):
         """Stop the audio source."""
-
-        return stop_node(self, time=time)
+        add_or_send_event("stop", self, {"time": time})
+        return self
 
 
 class Oscillator(Source):

--- a/ipytone/tests/test_effect.py
+++ b/ipytone/tests/test_effect.py
@@ -97,7 +97,6 @@ def test_tremolo():
     assert tre.state == "stopped"
 
     e = tre.start()
-    assert tre.state == "started"
     assert e is tre
 
     e = tre.stop()

--- a/ipytone/tests/test_effect.py
+++ b/ipytone/tests/test_effect.py
@@ -85,8 +85,9 @@ def test_reverb():
         rv.pre_delay = -1
 
 
-def test_tremolo():
+def test_tremolo(mocker):
     tre = Tremolo()
+    mocker.patch.object(tre, "send")
 
     assert tre.type == "sine"
     assert tre.frequency.value == 10
@@ -96,9 +97,15 @@ def test_tremolo():
     assert tre.spread == 180
 
     e = tre.start()
+    tre.send.assert_called_with(
+        {"event": "trigger", "method": "start", "args": {"time": None}, "arg_keys": ["time"]}
+    )
     assert e is tre
 
     e = tre.stop()
+    tre.send.assert_called_with(
+        {"event": "trigger", "method": "stop", "args": {"time": None}, "arg_keys": ["time"]}
+    )
     assert e is tre
 
     with pytest.raises(TraitError, match="Invalid oscillator type"):

--- a/ipytone/tests/test_effect.py
+++ b/ipytone/tests/test_effect.py
@@ -94,13 +94,11 @@ def test_tremolo():
     assert tre.depth.value == 0.5
     assert tre.depth.units == "normalRange"
     assert tre.spread == 180
-    assert tre.state == "stopped"
 
     e = tre.start()
     assert e is tre
 
     e = tre.stop()
-    assert tre.state == "stopped"
     assert e is tre
 
     with pytest.raises(TraitError, match="Invalid oscillator type"):

--- a/ipytone/tests/test_envelope.py
+++ b/ipytone/tests/test_envelope.py
@@ -40,6 +40,29 @@ def test_envelope():
         env.decay_curve = "sine"
 
 
+@pytest.mark.parametrize(
+    "method,js_method,kwargs",
+    [
+        ("trigger_attack", "triggerAttack", {"time": None, "velocity": 1}),
+        ("trigger_release", "triggerRelease", {"time": None}),
+        (
+            "trigger_attack_release",
+            "triggerAttackRelease",
+            {"duration": 1, "time": None, "velocity": 1},
+        ),
+    ],
+)
+def test_enveloppe_trigger(mocker, method, js_method, kwargs):
+    env = Envelope()
+    mocker.patch.object(env, "send")
+
+    expected = {"event": "trigger", "method": js_method, "args": kwargs, "arg_keys": list(kwargs)}
+
+    e = getattr(env, method)(**kwargs)
+    assert e is env
+    env.send.assert_called_once_with(expected)
+
+
 def test_amplitude_envelope():
     env = AmplitudeEnvelope()
 

--- a/ipytone/tests/test_source.py
+++ b/ipytone/tests/test_source.py
@@ -6,8 +6,9 @@ from ipytone import AudioBuffer, Noise, Oscillator, Player, Players, Volume
 from ipytone.source import Source
 
 
-def test_source():
+def test_source(mocker):
     node = Source()
+    mocker.patch.object(node, "send")
 
     assert node.mute is False
     assert isinstance(node.output, Volume)
@@ -15,8 +16,19 @@ def test_source():
 
     n = node.start()
     assert n is node
+    node.send.assert_called_with(
+        {
+            "event": "trigger",
+            "method": "start",
+            "args": {"time": None, "offset": None, "duration": None},
+            "arg_keys": ["time", "offset", "duration"],
+        }
+    )
 
     n = node.stop()
+    node.send.assert_called_with(
+        {"event": "trigger", "method": "stop", "args": {"time": None}, "arg_keys": ["time"]}
+    )
     assert n is node
 
 

--- a/ipytone/tests/test_source.py
+++ b/ipytone/tests/test_source.py
@@ -10,7 +10,6 @@ def test_source():
     node = Source()
 
     assert node.mute is False
-    assert node.state == "stopped"
     assert isinstance(node.output, Volume)
     assert node.volume is node.output.volume
 
@@ -96,7 +95,6 @@ def test_players():
     assert players.loaded is False
     assert players.fade_in == 0
     assert players.fade_out == 0
-    assert players.state == "stopped"
 
     a = players.get_player("A")
     assert isinstance(a, Player)

--- a/ipytone/tests/test_source.py
+++ b/ipytone/tests/test_source.py
@@ -15,11 +15,9 @@ def test_source():
     assert node.volume is node.output.volume
 
     n = node.start()
-    assert node.state == "started"
     assert n is node
 
     n = node.stop()
-    assert node.state == "stopped"
     assert n is node
 
 
@@ -111,11 +109,9 @@ def test_players():
     assert b.buffer.buffer_url == "another_url"
 
     a.start()
-    assert players.state == "started"
     b.start()
     p = players.stop_all()
     assert p is players
-    assert a.state == b.state == players.state == "stopped"
 
     players.fade_in = 1
     assert a.fade_in == b.fade_in == players.fade_in == 1

--- a/ipytone/tests/test_transport.py
+++ b/ipytone/tests/test_transport.py
@@ -107,12 +107,12 @@ def test_schedule_context_manager(mocker, func, cm_func, args, kwargs):
         osc.start(time).stop(time + 1)
 
     eid = func(clb, *args, **kwargs)
-    expected, = transport.send.call_args[0]
+    (expected,) = transport.send.call_args[0]
 
     with cm_func(*args, **kwargs) as (time, cm_eid):
         osc.start(time).stop(time + 1)
 
-    actual, = transport.send.call_args[0]
+    (actual,) = transport.send.call_args[0]
     assert eid != cm_eid
     actual["id"] = expected["id"]
 

--- a/ipytone/tests/test_transport.py
+++ b/ipytone/tests/test_transport.py
@@ -1,94 +1,87 @@
 import pytest
 
 from ipytone import transport
-from ipytone.source import Source
+from ipytone.source import Oscillator
+from ipytone.transport import Transport
 
 
-def to_refactor_transport():
-    assert transport.state == "stopped"
+def test_transport():
+    # signleton
+    assert Transport() is transport
 
-    toggle_schedule = False
-    py_event_id = 0
-    node = Source()
 
-    # schedule_repeat
-    interval = "8n"
-    start_time = "1m"
-    start = "time"
-    stop = "time + 0.1"
-    with transport.schedule_repeat(interval, start_time) as event_id:
-        assert transport._is_scheduling is True
-        assert transport._py_event_id == py_event_id
-        assert transport._audio_nodes == []
-        assert transport._methods == []
-        assert transport._packed_args == []
-        assert transport._toggle_schedule == toggle_schedule
-        node.start(start).stop(stop)
-        assert transport._audio_nodes == [node, node]
-        assert transport._methods == ["start", "stop"]
-        assert transport._packed_args == [f"{start} *** ", f"{stop} *** "]
-    toggle_schedule = not toggle_schedule
-    py_event_id += 1
-    assert transport._schedule_op == "scheduleRepeat"
-    assert transport._interval == interval
-    assert transport._start_time == start_time
-    assert transport._duration is None
-    assert transport._toggle_schedule == toggle_schedule
-    assert transport._is_scheduling is False
-    assert transport._py_event_id == py_event_id
+@pytest.mark.parametrize(
+    "op,func,expected_id,args,kwargs",
+    [
+        ("", transport.schedule, 0, {"time": "1m"}, {}),
+        (
+            "repeat",
+            transport.schedule_repeat,
+            1,
+            {"interval": "2"},
+            {"start_time": 0, "duration": None},
+        ),
+        ("once", transport.schedule_once, 2, {"time": "1m"}, {}),
+    ],
+)
+def test_transport_schedule(mocker, op, func, expected_id, args, kwargs):
+    mocker.patch.object(transport, "send")
 
-    transport.start()
-    assert transport.state == "started"
+    osc = Oscillator()
 
-    assert transport._toggle_clear is False
-    transport.clear(event_id)
-    assert transport._toggle_clear is True
-    assert transport._clear_event_id == event_id
-    with pytest.raises(RuntimeError):
-        transport.clear(event_id)
+    def clb(time):
+        osc.start(time).stop(time + 1)
 
-    transport.stop()
-    assert transport.state == "stopped"
+    eid = func(clb, *args.values(), **kwargs)
+    assert eid == expected_id
 
-    # schedule
-    time = "2m"
-    start = "time + 0.2"
-    stop = "time + 0.3"
-    with transport.schedule(time) as event_id:
-        assert transport._is_scheduling is True
-        assert transport._py_event_id == py_event_id
-        assert transport._audio_nodes == []
-        assert transport._methods == []
-        assert transport._packed_args == []
-        assert transport._toggle_schedule == toggle_schedule
-        node.start(start).stop(stop)
-        assert transport._audio_nodes == [node, node]
-        assert transport._methods == ["start", "stop"]
-        assert transport._packed_args == [f"{start} *** ", f"{stop} *** "]
-    toggle_schedule = not toggle_schedule
-    py_event_id += 1
-    assert transport._schedule_op == "schedule"
-    assert transport._start_time == time
-    assert transport._toggle_schedule == toggle_schedule
-    assert transport._is_scheduling is False
-    assert transport._py_event_id == py_event_id
+    expected = {
+        "event": "schedule",
+        "op": op,
+        "id": expected_id,
+        "items": [
+            {
+                "method": "start",
+                "callee": osc.model_id,
+                "args": {"time": "time", "offset": None, "duration": None},
+                "arg_keys": ["time", "offset", "duration"],
+            },
+            {
+                "method": "stop",
+                "callee": osc.model_id,
+                "args": {"time": "time + 1"},
+                "arg_keys": ["time"],
+            },
+        ],
+    }
+    expected.update(args)
+    expected.update(kwargs)
 
-    # schedule_once
-    time = "3m"
-    start = "time + 0.4"
-    stop = "time + 0.5"
-    with transport.schedule_once(time) as event_id:
-        assert transport._is_scheduling is True
-        assert transport._audio_nodes == []
-        assert transport._methods == []
-        assert transport._packed_args == []
-        assert transport._toggle_schedule == toggle_schedule
-        node.start(start).stop(stop)
-        assert transport._audio_nodes == [node, node]
-        assert transport._methods == ["start", "stop"]
-        assert transport._packed_args == [f"{start} *** ", f"{stop} *** "]
-    toggle_schedule = not toggle_schedule
-    assert transport._schedule_op == "scheduleOnce"
-    assert transport._start_time == time
-    assert transport._toggle_schedule == toggle_schedule
-    assert transport._is_scheduling is False
+    transport.send.assert_called_with(expected)
+
+    if op != "once":
+        t = transport.clear(eid)
+        assert t is transport
+        transport.send.assert_called_with({"event": "clear", "id": eid})
+
+    with pytest.raises(ValueError, match=".*event ID not found.*"):
+        transport.clear(eid)
+
+
+@pytest.mark.parametrize(
+    "method,args",
+    [
+        ("start", {"time": None, "offset": None}),
+        ("stop", {"time": None}),
+        ("pause", {"time": None}),
+        ("toggle", {"time": None}),
+    ],
+)
+def test_transport_play(mocker, method, args):
+    mocker.patch.object(transport, "send")
+
+    expected = {"event": "play", "method": method, "args": args, "arg_keys": list(args)}
+
+    t = getattr(transport, method)(*args.values())
+    assert t is transport
+    transport.send.assert_called_once_with(expected)

--- a/ipytone/tests/test_transport.py
+++ b/ipytone/tests/test_transport.py
@@ -4,7 +4,7 @@ from ipytone import transport
 from ipytone.source import Source
 
 
-def test_transport():
+def to_refactor_transport():
     assert transport.state == "stopped"
 
     toggle_schedule = False

--- a/ipytone/tests/test_transport.py
+++ b/ipytone/tests/test_transport.py
@@ -107,12 +107,12 @@ def test_schedule_context_manager(mocker, func, cm_func, args, kwargs):
         osc.start(time).stop(time + 1)
 
     eid = func(clb, *args, **kwargs)
-    expected = transport.send.call_args.args[0]
+    expected, = transport.send.call_args[0]
 
     with cm_func(*args, **kwargs) as (time, cm_eid):
         osc.start(time).stop(time + 1)
 
-    actual = transport.send.call_args.args[0]
+    actual, = transport.send.call_args[0]
     assert eid != cm_eid
     actual["id"] = expected["id"]
 

--- a/ipytone/transport.py
+++ b/ipytone/transport.py
@@ -49,7 +49,6 @@ def add_or_send_event(name, callee, args, event="trigger"):
         time.items.append(data)
     else:
         data["event"] = event
-        data.update(args)
         callee.send(data)
 
 

--- a/ipytone/transport.py
+++ b/ipytone/transport.py
@@ -129,38 +129,3 @@ class Transport(ToneObject):
 
 
 transport = Transport()
-
-
-def start_node(node, time=""):
-    """Start an audio node.
-
-    The node will either start immediately or as specified by ``time`` if this
-    function is called within a transport scheduling context.
-
-    """
-    # if transport._is_scheduling:
-    #    transport._audio_nodes = transport._audio_nodes + [node]
-    #    transport._methods = transport._methods + ["start"]
-    #    transport._packed_args = transport._packed_args + [time + " *** "]
-    # else:
-    node.state = "started"
-
-    return node
-
-
-def stop_node(node, time=""):
-    """Stop an audio node.
-
-    The node will either stop immediately or as specified by ``time`` if this
-    function is called within a transport scheduling context.
-
-    """
-    # if transport._is_scheduling:
-    #    transport._audio_nodes = transport._audio_nodes + [node]
-    #    transport._methods = transport._methods + ["stop"]
-    #    transport._packed_args = transport._packed_args + [time + " *** "]
-    # else:
-    if node.state == "started":
-        node.state = "stopped"
-
-    return node

--- a/ipytone/transport.py
+++ b/ipytone/transport.py
@@ -85,12 +85,54 @@ class Transport(ToneObject):
         return event_id
 
     def schedule(self, callback, time):
+        """Schedule an event along the transport timeline.
+
+        Parameters
+        ----------
+        callback : callable
+            The callback to be invoked at the scheduled time. It must accept exactly
+            one argument that corresponds to the time value (in seconds).
+        time : str or float
+            The time to invoke the callback at (any value/units supported by
+            Tone.js ``Time``).
+
+        Returns
+        -------
+        event_id : int
+            The id of the event which can be used for canceling the event.
+
+        """
         items = self._get_callback_items(callback)
         event_id = self._get_event_id_and_inc()
         self.send({"event": "schedule", "op": "", "id": event_id, "items": items, "time": time})
         return event_id
 
     def schedule_repeat(self, callback, interval, start_time=0, duration=None):
+        """Schedule a repeated event along the transport timeline.
+
+        The event may start at a given time and may be repeated only for a
+        specified duration.
+
+        Parameters
+        ----------
+        callback : callable
+            The callback to be invoked at the scheduled time. It must accept exactly
+            one argument that corresponds to the time value (in seconds).
+        interval : str or float
+            The duration between successive callbacks (any value/units supported by
+            Tone.js ``Time`` but must be positive).
+        start_time : str or float, optional
+            When along the timeline the events should start being invoked (default: at the
+            beginning of the timeline).
+        duration : str or float, optional
+            How long the event should repeat (default: indefinitely).
+
+        Returns
+        -------
+        event_id : int
+            The id of the event which can be used for canceling the event.
+
+        """
         items = self._get_callback_items(callback)
         event_id = self._get_event_id_and_inc()
         self.send(
@@ -107,12 +149,39 @@ class Transport(ToneObject):
         return event_id
 
     def schedule_once(self, callback, time):
+        """Schedule an event along the transport timeline.
+
+        After being invoked, the event is removed.
+
+        Parameters
+        ----------
+        callback : callable
+            The callback to be invoked at the scheduled time. It must accept exactly
+            one argument that corresponds to the time value (in seconds).
+        time : str or float
+            The time to invoke the callback at (any value/units supported by
+            Tone.js ``Time``).
+
+        Returns
+        -------
+        event_id : int
+            The id of the event which can be used for canceling the event.
+
+        """
         items = self._get_callback_items(callback)
         event_id = self._get_event_id_and_inc(append=False)
         self.send({"event": "schedule", "op": "once", "id": event_id, "items": items, "time": time})
         return event_id
 
     def clear(self, event_id):
+        """Clear an event from the timeline.
+
+        Parameters
+        ----------
+        event_id : int
+            The id of the event to clear.
+
+        """
         if event_id not in self._all_event_id:
             raise ValueError(f"Scheduled event ID not found: {event_id}")
         self.send({"event": "clear", "id": event_id})

--- a/ipytone/transport.py
+++ b/ipytone/transport.py
@@ -59,9 +59,10 @@ class Transport(ToneObject):
         callback(callback_arg)
         return callback_arg.items
 
-    def _get_event_id_and_inc(self):
+    def _get_event_id_and_inc(self, append=True):
         event_id = self._py_event_id
-        self._all_event_id.append(event_id)
+        if append:
+            self._all_event_id.append(event_id)
         self._py_event_id += 1
         return event_id
 
@@ -89,9 +90,9 @@ class Transport(ToneObject):
 
     def schedule_once(self, callback, time):
         items = self._get_callback_items(callback)
-        event_id = self._get_event_id_and_inc()
+        event_id = self._get_event_id_and_inc(append=False)
         self.send(
-            {"event": "schedule_once", "op": "once", "id": event_id, "items": items, "time": time}
+            {"event": "schedule", "op": "once", "id": event_id, "items": items, "time": time}
         )
         return event_id
 

--- a/ipytone/transport.py
+++ b/ipytone/transport.py
@@ -6,6 +6,28 @@ from traitlets import Bool, Enum, Instance, Int, List, Unicode
 from .base import ToneWidgetBase
 
 
+class BaseCallbackArg:
+    """Base class internally used as a placeholder for any tone event or
+    scheduling callback argument.
+
+    """
+
+    def __init__(self, call_id, caller_widget, value=None):
+        self.call_id = call_id
+        self.caller_widget = caller_widget
+        self.value = value
+
+
+class ScheduleCallbackArg(BaseCallbackArg):
+
+    def __init__(self, *args, value="time"):
+        super().__init__(*args, value=value)
+
+    def __add__(self, other):
+        return ScheduleCallbackArg(self.call_id, self.caller_widget, value=f"{self.value} + {other}")
+
+
+
 class Transport(ToneWidgetBase):
     """Transport for timing musical events."""
 
@@ -37,6 +59,13 @@ class Transport(ToneWidgetBase):
         self._is_scheduling = False
         self._all_event_id = []
         super(Transport, self).__init__(**kwargs)
+
+    def schedule_alt(self, callback, time):
+        call_id = "a-random-id"
+        callback_arg = ScheduleCallbackArg(call_id, self)
+        callback(callback_arg)
+
+        self.send({'event': 'schedule', 'call_id': call_id, 'time': time})
 
     @contextlib.contextmanager
     def schedule(self, time):

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup_args = dict(
         "test": [
             "pytest>=4.6",
             "pytest-cov",
+            "pytest-mock",
         ],
     },
     entry_points={},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+export function normalizeArguments(args: any, argsKeys: string[]): any[] {
+  return argsKeys.map((name: string) => {
+    if (args[name] === null) {
+      return undefined;
+    } else {
+      return args[name];
+    }
+  });
+}

--- a/src/widget_effect.ts
+++ b/src/widget_effect.ts
@@ -189,7 +189,6 @@ export class TremoloModel extends AudioNodeModel {
       _depth: undefined,
       type: 'sine',
       spread: 180,
-      state: 'stopped',
     };
   }
 
@@ -229,7 +228,6 @@ export class TremoloModel extends AudioNodeModel {
     this.on('change:type', () => {
       this.node.type = this.type;
     });
-    this.on('change:state', this.startStopNode, this);
     this.on('msg:custom', this.handleMsg, this);
   }
 
@@ -239,23 +237,11 @@ export class TremoloModel extends AudioNodeModel {
       if (time === null) {
         time = undefined;
       }
-      // TODO: state will not be properly updated if time offset is defined
-      // maybe we compute when it should be sync again in the future and use setTimeout
       if (command.method === 'start') {
         this.node.start(time);
-        this.set('state', 'started', { silent: true });
       } else if (command.method === 'stop') {
         this.node.stop(time);
-        this.set('state', 'stopped', { silent: true });
       }
-    }
-  }
-
-  private startStopNode(): void {
-    if (this.get('state') === 'started') {
-      this.node.start(0);
-    } else {
-      this.node.stop(0);
     }
   }
 

--- a/src/widget_effect.ts
+++ b/src/widget_effect.ts
@@ -244,8 +244,7 @@ export class TremoloModel extends AudioNodeModel {
       if (command.method === 'start') {
         this.node.start(time);
         this.set('state', 'started', { silent: true });
-      }
-      else if (command.method === 'stop') {
+      } else if (command.method === 'stop') {
         this.node.stop(time);
         this.set('state', 'stopped', { silent: true });
       }

--- a/src/widget_effect.ts
+++ b/src/widget_effect.ts
@@ -230,6 +230,26 @@ export class TremoloModel extends AudioNodeModel {
       this.node.type = this.type;
     });
     this.on('change:state', this.startStopNode, this);
+    this.on('msg:custom', this.handleMsg, this);
+  }
+
+  private handleMsg(command: any, buffers: any): void {
+    if (command.event === 'trigger') {
+      let time = command.args.time;
+      if (time === null) {
+        time = undefined;
+      }
+      // TODO: state will not be properly updated if time offset is defined
+      // maybe we compute when it should be sync again in the future and use setTimeout
+      if (command.method === 'start') {
+        this.node.start(time);
+        this.set('state', 'started', { silent: true });
+      }
+      else if (command.method === 'stop') {
+        this.node.stop(time);
+        this.set('state', 'stopped', { silent: true });
+      }
+    }
   }
 
   private startStopNode(): void {

--- a/src/widget_envelope.ts
+++ b/src/widget_envelope.ts
@@ -81,7 +81,7 @@ export class EnvelopeModel extends AudioNodeModel {
     this.maybeSetArray();
   }
 
-  handleMsg(command: any, buffers: any): void {
+  private handleMsg(command: any, buffers: any): void {
     if (command.event === 'trigger') {
       const argsArray = normalizeArguments(command.args, command.arg_keys);
       (this.node as any)[command.method](...argsArray);

--- a/src/widget_envelope.ts
+++ b/src/widget_envelope.ts
@@ -88,7 +88,18 @@ export class EnvelopeModel extends AudioNodeModel {
         this.node.triggerRelease();
         break;
       case 'triggerAttackRelease':
-        this.node.triggerAttackRelease(command.duration);
+        console.log(command);
+        if (command.schedule) {
+          const callback = (time: number) => {
+            this.node.triggerAttackRelease(command.duration, time);
+          };
+          Promise.resolve(this.widget_manager.get_model(command.caller_widget)).then((model: any) => {
+            console.log(model);
+            model.appendCallback(command.call_id, callback);
+          });
+        } else {
+          this.node.triggerAttackRelease(command.duration);
+        }
         break;
     }
   }

--- a/src/widget_envelope.ts
+++ b/src/widget_envelope.ts
@@ -2,6 +2,8 @@ import { ISerializers } from '@jupyter-widgets/base';
 
 import * as tone from 'tone';
 
+import { normalizeArguments } from './utils';
+
 import { AudioNodeModel } from './widget_base';
 
 import {
@@ -80,16 +82,9 @@ export class EnvelopeModel extends AudioNodeModel {
   }
 
   handleMsg(command: any, buffers: any): void {
-    switch (command.event) {
-      case 'triggerAttack':
-        this.node.triggerAttack();
-        break;
-      case 'triggerRelease':
-        this.node.triggerRelease();
-        break;
-      case 'triggerAttackRelease':
-        this.node.triggerAttackRelease(command.duration);
-        break;
+    if (command.event === 'trigger') {
+      const argsArray = normalizeArguments(command.args, command.arg_keys);
+      (this.node as any)[command.method](...argsArray);
     }
   }
 

--- a/src/widget_envelope.ts
+++ b/src/widget_envelope.ts
@@ -88,18 +88,7 @@ export class EnvelopeModel extends AudioNodeModel {
         this.node.triggerRelease();
         break;
       case 'triggerAttackRelease':
-        console.log(command);
-        if (command.schedule) {
-          const callback = (time: number) => {
-            this.node.triggerAttackRelease(command.duration, time);
-          };
-          Promise.resolve(this.widget_manager.get_model(command.caller_widget)).then((model: any) => {
-            console.log(model);
-            model.appendCallback(command.call_id, callback);
-          });
-        } else {
-          this.node.triggerAttackRelease(command.duration);
-        }
+        this.node.triggerAttackRelease(command.duration);
         break;
     }
   }
@@ -121,7 +110,7 @@ export class EnvelopeModel extends AudioNodeModel {
       this.updateEnvelope('release_curve', 'releaseCurve')
     );
 
-    this.on('msg:custom', this.handleMsg.bind(this));
+    this.on('msg:custom', this.handleMsg, this);
   }
 
   node: tone.Envelope;

--- a/src/widget_source.ts
+++ b/src/widget_source.ts
@@ -4,6 +4,8 @@ import * as tone from 'tone';
 
 // import * as source from 'tone/Tone/source/Source';
 
+import { normalizeArguments } from './utils';
+
 import { AudioNodeModel } from './widget_base';
 
 import { AudioBufferModel, AudioBuffersModel, ParamModel } from './widget_core';
@@ -39,6 +41,17 @@ abstract class SourceModel extends AudioNodeModel {
       this.volume.save_changes();
     });
     this.on('change:state', this.startStopNode, this);
+    this.on('msg:custom', this.handleMsg, this);
+  }
+
+  private handleMsg(command: any, buffers: any): void {
+    if (command.event === 'trigger') {
+      const argsArray = normalizeArguments(command.args, command.arg_keys);
+      (this.node as any)[command.method](...argsArray);
+      // TODO: state will not be properly updated if time offset/duration is defined
+      // maybe we compute when it should be sync again in the future and use setTimeout
+      this.set('state', this.node.state, { silent: true });
+    }
   }
 
   private startStopNode(): void {

--- a/src/widget_source.ts
+++ b/src/widget_source.ts
@@ -17,7 +17,6 @@ abstract class SourceModel extends AudioNodeModel {
     return {
       ...super.defaults(),
       _model_name: SourceModel.model_name,
-      state: 'stopped',
       _volume: undefined,
       mute: false,
     };
@@ -40,7 +39,6 @@ abstract class SourceModel extends AudioNodeModel {
       this.volume.value = this.node.volume.value;
       this.volume.save_changes();
     });
-    this.on('change:state', this.startStopNode, this);
     this.on('msg:custom', this.handleMsg, this);
   }
 
@@ -48,17 +46,6 @@ abstract class SourceModel extends AudioNodeModel {
     if (command.event === 'trigger') {
       const argsArray = normalizeArguments(command.args, command.arg_keys);
       (this.node as any)[command.method](...argsArray);
-      // TODO: state will not be properly updated if time offset/duration is defined
-      // maybe we compute when it should be sync again in the future and use setTimeout
-      this.set('state', this.node.state, { silent: true });
-    }
-  }
-
-  private startStopNode(): void {
-    if (this.get('state') === 'started') {
-      this.node.start(0);
-    } else {
-      this.node.stop(0);
     }
   }
 

--- a/src/widget_transport.ts
+++ b/src/widget_transport.ts
@@ -1,36 +1,25 @@
 import {
   WidgetModel,
   ISerializers,
-  unpack_models,
 } from '@jupyter-widgets/base';
 
 import * as tone from 'tone';
 
-import { ToneWidgetModel } from './widget_base';
+import { ToneObjectModel } from './widget_base';
 
-export class TransportModel extends WidgetModel {
+type transportCallback = { (time: number): void };
+
+export class TransportModel extends ToneObjectModel {
   defaults(): any {
     return {
       ...super.defaults(),
       _model_name: TransportModel.model_name,
-      _toggle_schedule: false,
-      _toggle_clear: false,
-      _schedule_op: '',
-      _audio_nodes: [],
-      _methods: [],
-      _packed_args: [],
-      _interval: '',
-      _start_time: '',
-      _duration: null,
-      _py_event_id: 0,
-      _clear_event_id: 0,
       state: 'stopped',
     };
   }
 
   static serializers: ISerializers = {
-    ...ToneWidgetModel.serializers,
-    _audio_nodes: { deserialize: unpack_models as any },
+    ...ToneObjectModel.serializers,
   };
 
   initialize(
@@ -39,16 +28,11 @@ export class TransportModel extends WidgetModel {
   ): void {
     super.initialize(attributes, options);
     this.py2jsEventID = {};
-    this.event_callbacks = {};
-    this.initEventListeners();
   }
 
   initEventListeners(): void {
     this.on('change:state', this.startStopTransport, this);
-    this.on('change:_toggle_schedule', this.schedule, this);
-    this.on('change:_toggle_clear', this.clear_event, this);
-
-    this.on('msg:custom', this.handleMsg.bind(this));
+    this.on('msg:custom', this.handleMsg, this);
   }
 
   private startStopTransport(): void {
@@ -59,82 +43,83 @@ export class TransportModel extends WidgetModel {
     }
   }
 
-  appendCallback(call_id: string, callback: {(time: number): void;}): void {
-    if (!(call_id in this.event_callbacks)) {
-      this.event_callbacks[call_id] = [];
+  private getToneCallback(items: any): Promise<transportCallback> {
+    const itemsModel = items.map((data: any) => {
+      return Promise.resolve(this.widget_manager.get_model(data.callee)).then(
+        (model: WidgetModel | undefined) => {
+          const item = { ...data };
+          item.model = model;
+          return item;
+        }
+      );
+    });
+
+    return Promise.all(itemsModel).then((items) => {
+      const callback = (time: number) => {
+        items.forEach((item: any) => {
+          const argsArray = item.arg_keys.map((name: string) => {
+            if (name === 'time') {
+              return eval(item.args[name]);
+            } else {
+              return item.args[name];
+            }
+          });
+
+          item.model.node[item.method](...argsArray);
+        });
+      };
+
+      return callback;
+    });
+  }
+
+  private schedule(command: any): void {
+    const callback = Promise.resolve(this.getToneCallback(command.items));
+
+    if (command.op === '') {
+      callback.then((clb) => {
+        this.py2jsEventID[command.id] = tone.Transport.schedule(
+          clb,
+          command.time
+        );
+      });
+    } else if (command.op === 'repeat') {
+      let duration = Infinity;
+      if (command.duration) {
+        duration = command.duration;
+      }
+      callback.then((clb) => {
+        this.py2jsEventID[command.id] = tone.Transport.scheduleRepeat(
+          clb,
+          command.interval,
+          command.start_time,
+          duration
+        );
+      });
+    } else if (command.op === 'once') {
+      callback.then((clb) => {
+        this.py2jsEventID[command.id] = tone.Transport.scheduleOnce(
+          clb,
+          command.time
+        );
+      });
     }
-    this.event_callbacks[call_id].push(callback);
   }
 
   handleMsg(command: any, buffers: any): void {
     if (command.event === 'schedule') {
-      const callbacks = this.event_callbacks[command.call_id];
-      console.log(callbacks);
-      const schedule_callback = (time: number) => {
-        callbacks.forEach((clb) => clb(time));
-      }
-      tone.Transport.schedule(schedule_callback, command.time)
+      this.schedule(command);
+    } else if (command.event === 'clear') {
+      this.clearEvent(command.id);
     }
   }
 
-  private schedule(): void {
-    const schedule_op = this.get('_schedule_op');
-    const audioNodes = this.get('_audio_nodes');
-    const methods = this.get('_methods');
-    const packed_args = this.get('_packed_args');
-    const callback = function (time: number) {
-      for (let i = 0; i < audioNodes.length; i++) {
-        const audioNode = audioNodes[i].node;
-        const method = methods[i];
-        const args = packed_args[i].split(' *** ');
-        args.pop();
-        for (let j = 0; j < args.length; j++) {
-          args[j] = eval(args[j]);
-        }
-        if (method === 'start') {
-          audioNode.start(...args);
-        } else if (method === 'stop') {
-          audioNode.stop(...args);
-        }
-      }
-    };
-    let eventID;
-    if (schedule_op === 'schedule') {
-      const time = this.get('_start_time');
-      eventID = tone.Transport.schedule(callback, time);
-    } else if (schedule_op === 'scheduleOnce') {
-      const time = this.get('_start_time');
-      eventID = tone.Transport.scheduleOnce(callback, time);
-    } else if (schedule_op === 'scheduleRepeat') {
-      const interval = this.get('_interval');
-      const startTime = this.get('_start_time');
-      let duration = this.get('_duration');
-      if (!duration) {
-        duration = Infinity;
-      }
-      eventID = tone.Transport.scheduleRepeat(
-        callback,
-        interval,
-        startTime,
-        duration
-      );
-    } else {
-      return;
-    }
-    if (schedule_op !== 'scheduleOnce') {
-      const pyEventID = this.get('_py_event_id');
-      this.py2jsEventID[pyEventID] = eventID;
-    }
-  }
-
-  private clear_event(): void {
-    const pyEventID = this.get('_clear_event_id');
+  private clearEvent(pyEventID: number): void {
     tone.Transport.clear(this.py2jsEventID[pyEventID]);
     delete this.py2jsEventID[pyEventID];
   }
 
   py2jsEventID: { [id: number]: number };
-  event_callbacks: { [id: string]: {(time: number): void; }[]};
 
   static model_name = 'TransportModel';
 }

--- a/src/widget_transport.ts
+++ b/src/widget_transport.ts
@@ -13,7 +13,6 @@ export class TransportModel extends ToneObjectModel {
     return {
       ...super.defaults(),
       _model_name: TransportModel.model_name,
-      state: 'stopped',
     };
   }
 
@@ -30,16 +29,7 @@ export class TransportModel extends ToneObjectModel {
   }
 
   initEventListeners(): void {
-    this.on('change:state', this.startStopTransport, this);
     this.on('msg:custom', this.handleMsg, this);
-  }
-
-  private startStopTransport(): void {
-    if (this.get('state') === 'started') {
-      tone.Transport.start();
-    } else {
-      tone.Transport.stop();
-    }
   }
 
   private getToneCallback(items: any): Promise<transportCallback> {
@@ -100,9 +90,16 @@ export class TransportModel extends ToneObjectModel {
     }
   }
 
-  handleMsg(command: any, buffers: any): void {
+  private play(command: any): void {
+    const argsArray = normalizeArguments(command.args, command.arg_keys);
+    (tone.Transport as any)[command.method](...argsArray);
+  }
+
+  private handleMsg(command: any, buffers: any): void {
     if (command.event === 'schedule') {
       this.schedule(command);
+    } else if (command.event === 'play') {
+      this.play(command);
     } else if (command.event === 'clear') {
       this.clearEvent(command.id);
     }

--- a/src/widget_transport.ts
+++ b/src/widget_transport.ts
@@ -1,9 +1,8 @@
-import {
-  WidgetModel,
-  ISerializers,
-} from '@jupyter-widgets/base';
+import { WidgetModel, ISerializers } from '@jupyter-widgets/base';
 
 import * as tone from 'tone';
+
+import { normalizeArguments } from './utils';
 
 import { ToneObjectModel } from './widget_base';
 
@@ -57,14 +56,9 @@ export class TransportModel extends ToneObjectModel {
     return Promise.all(itemsModel).then((items) => {
       const callback = (time: number) => {
         items.forEach((item: any) => {
-          const argsArray = item.arg_keys.map((name: string) => {
-            if (name === 'time') {
-              return eval(item.args[name]);
-            } else {
-              return item.args[name];
-            }
-          });
-
+          const args = { ...item.args };
+          args.time = eval(args.time);
+          const argsArray = normalizeArguments(args, item.arg_keys);
           item.model.node[item.method](...argsArray);
         });
       };


### PR DESCRIPTION
@davidbrochart, in this PR I have refactored how to pass callbacks to the front-end side.

The "stateless" approach here (based on function argument placeholders and custom widget messages) is a bit more convoluted, but I think it will generalize more easily to all `Tone` object methods that can be scheduled (`start`, `stop`, `triggerAttackRelease`, `setValueAtTime`, `linearRampTo`, etc... there are many) and also to the various [ToneEvent](https://tonejs.github.io/docs/14.7.77/ToneEvent) sub-classes that I'd like to expose later (and for which the callbacks may have different signatures).

It also allows writing:

```python
env = ipytone.AmplitudeEnvelope(sync_array=True).to_destination()
osc = ipytone.Oscillator().connect(env).start()

def clb(time):
    # time can now be used as a "regular" variable (not a string)
    env.trigger_attack_release(0.2, time)
    env.trigger_attack_release(0.1, time + 0.4)

event_id = ipytone.transport.schedule_repeat(clb, "1m")

ipytone.transport.clear(event_id)

# we can reuse the same callback in a different scheduling
ipytone.transport.schedule_once(clb, 0)
```

I still like the context managers, so I think we could add it back, e.g., as top-level functions:

```python
with ipytone.schedule_repeat("1m") as (time, event_id):
    env.trigger_attack_release(0.2, time)
    env.trigger_attack_release(0.1, time + 0.4)
```

What do you think?