### PR TITLE
add PyAudioNode

### DIFF
--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from ._version import __version__, version_info
+from .base import PyAudioNode
 from .channel import CrossFade
 from .core import AudioBuffer, AudioBuffers, Gain, Param, Volume, destination
 from .effect import Distortion, FeedbackDelay, PingPongDelay, Reverb, Tremolo, Vibrato

--- a/ipytone/envelope.py
+++ b/ipytone/envelope.py
@@ -89,7 +89,7 @@ class FrequencyEnvelope(Envelope):
         kwargs.update({"base_frequency": base_frequency, "octaves": octaves, "exponent": exponent})
 
         in_node = Pow(value=exponent)
-        out_node = Scale(min_out=base_frequency, max_out=base_frequency * 2 ** octaves)
+        out_node = Scale(min_out=base_frequency, max_out=base_frequency * 2**octaves)
         kwargs.update({"_input": in_node, "_output": out_node})
 
         super().__init__(**kwargs)

--- a/ipytone/tests/test_envelope.py
+++ b/ipytone/tests/test_envelope.py
@@ -79,5 +79,5 @@ def test_frequency_envelope():
     assert env.input.value == env.exponent == 1
     assert isinstance(env.output, Scale)
     assert env.output.min_out == env.base_frequency == 200.0
-    assert env.output.max_out == 200.0 * 2 ** 4
+    assert env.output.max_out == 200.0 * 2**4
     assert env.octaves == 4

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Benoit Bovy
 // Distributed under the terms of the Modified BSD License.
 
-export { NativeAudioNodeModel, NativeAudioParamModel } from './widget_base';
+export { NativeAudioNodeModel, NativeAudioParamModel, PyInternalAudioNodeModel } from './widget_base';
 export * from './widget_channel';
 export * from './widget_core';
 export * from './widget_effect';

--- a/src/widget_base.ts
+++ b/src/widget_base.ts
@@ -216,3 +216,44 @@ export abstract class AudioNodeModel extends NodeWithContextModel {
 
   static model_name = 'AudioNodeModel';
 }
+
+/**
+ * A basic Tone.js audio node that just accepts any input/output.
+ * It is meant to be wrapped by a PyInternalAudioNode widget.
+ */
+export class PyToneAudioNode extends tone.ToneAudioNode
+{
+  readonly name: string = "PyToneAudioNode";
+
+  private _input: tone.InputNode | undefined = undefined;
+  private _output: tone.OutputNode | undefined = undefined;
+
+  readonly input: tone.InputNode | undefined = this._input;
+  readonly output: tone.OutputNode | undefined = this._output;
+
+  constructor(input?: tone.InputNode, output?: tone.OutputNode)
+  {
+    super();
+    this._input = input;
+    this._output = output;
+  }
+}
+
+export class PyInternalAudioNodeModel extends AudioNodeModel
+{
+  defaults(): any {
+    return {
+      ...super.defaults(),
+      _model_name: PyInternalAudioNodeModel.model_name,
+    };
+  }
+
+  createNode(): PyToneAudioNode
+  {
+    return new PyToneAudioNode(this.input.node, this.output.node);
+  }
+
+  node: PyToneAudioNode;
+
+  static model_name = 'PyInternalAudioNodeModel';
+}


### PR DESCRIPTION
This class may be used as a base class to create new audio node subclasses only on the Python side (no JS code required). This is useful for implementing custom or high-level audio nodes on top of existing nodes.

Although a `PyAudioNode` object behaves like an audio node, it is not itself an `AudioNode`, i.e., it is not an ipywidgets widget. It may be built on top of other audio nodes or params (input, output...), which ultimately should be ipytone widgets in order to process some audio signal.