### PR TITLE
Callback time arg: force convert values to seconds

### DIFF
--- a/ipytone/callback.py
+++ b/ipytone/callback.py
@@ -56,17 +56,22 @@ class TimeCallbackArg(BaseCallbackArg):
     It has limited support for arithmetic operations.
 
     TODO: add more arithmetic operators
-    TODO: support converting any Tone time string to seconds
 
     """
 
     def __init__(self, *args, value="time", **kwargs):
         super().__init__(*args, value=value, **kwargs)
 
+    def _normalize_value(self, value):
+        if isinstance(value, TimeCallbackArg):
+            return value.value
+        else:
+            # force converting any given value to seconds in the front-end
+            # TODO: escape value to prevent any abuse in the front-end
+            return f"this.toSeconds({value!r})"
+
     def __add__(self, other):
-        # TODO: escape `other` converted string passed to self.derive
-        # in order to prevent any abuse in the front-end
-        return self.derive(f"{self.value} + {other}")
+        return self.derive(f"{self.value} + {self._normalize_value(other)}")
 
 
 class EventValueCallbackArg(BaseCallbackArg):

--- a/ipytone/tests/test_transport.py
+++ b/ipytone/tests/test_transport.py
@@ -85,7 +85,7 @@ def test_transport_schedule(mocker, op, func, expected_id, args, kwargs):
             {
                 "method": "stop",
                 "callee": osc.model_id,
-                "args": {"time": {"value": "time + 1", "eval": True}},
+                "args": {"time": {"value": "time + this.toSeconds(1)", "eval": True}},
                 "arg_keys": ["time"],
             },
         ],

--- a/src/widget_event.ts
+++ b/src/widget_event.ts
@@ -18,6 +18,8 @@ interface Event {
   playbackRate: tone.Unit.Positive;
   cancel: (time?: tone.Unit.TransportTime) => void;
   dispose: () => void;
+  toSeconds: (time: tone.Unit.Time) => tone.Unit.Seconds;
+  toFrequency: (frequency: tone.Unit.Frequency) => tone.Unit.Hertz;
 }
 
 abstract class BaseEventModel<T extends Event> extends NodeWithContextModel {
@@ -46,6 +48,14 @@ abstract class BaseEventModel<T extends Event> extends NodeWithContextModel {
   }
 
   protected abstract createEvent(): T;
+
+  protected toSeconds(time: tone.Unit.Time): tone.Unit.Seconds {
+    return this.event.toSeconds(time);
+  }
+
+  protected toFrequency(frequency: tone.Unit.Frequency): tone.Unit.Hertz {
+    return this.event.toFrequency(frequency);
+  }
 
   // attach widget models to items
   private async getCallbackItems(items: any): Promise<callbackItem[]> {

--- a/src/widget_transport.ts
+++ b/src/widget_transport.ts
@@ -46,6 +46,14 @@ export class TransportModel extends ToneObjectModel {
     return this.get('_bpm');
   }
 
+  protected toSeconds(time: tone.Unit.Time): tone.Unit.Seconds {
+    return tone.Transport.toSeconds(time);
+  }
+
+  protected toFrequency(frequency: tone.Unit.Frequency): tone.Unit.Hertz {
+    return tone.Transport.toFrequency(frequency);
+  }
+
   // attach widget models to items
   private async getCallbackItems(items: any): Promise<callbackItem[]> {
     const itemsModel: callbackItem[] = items.map(async (data: any) => {


### PR DESCRIPTION
This allows writing:

```python
env = ipytone.AmplitudeEnvelope()

def callback(time):
    # `time` is always given is seconds in Tone.js callbacks.
    # Below, "8n" will be automatically converted to seconds in the front-end
    env.trigger_attack_release("32n", time + "8n")
```