### PR TITLE
Add schedule observer widget

### DIFF
--- a/ipytone/core.py
+++ b/ipytone/core.py
@@ -2,7 +2,7 @@ import math
 
 import numpy as np
 from ipywidgets import Widget, widget_serialization
-from traitlets import Bool, Dict, Enum, Float, Instance, Int, Unicode, Union
+from traitlets import Bool, Dict, Enum, Float, Instance, Int, List, Unicode, Union
 from traittypes import Array
 
 from .base import AudioNode, NativeAudioNode, NativeAudioParam, NodeWithContext, ToneObject
@@ -222,6 +222,8 @@ class Param(NodeWithContext, ParamScheduleMixin, ScheduleObserveMixin):
     _swappable = Bool(False).tag(sync=True)
     overridden = Bool(False).tag(sync=True)
     convert = Bool(help="If True, convert the value into the specified units").tag(sync=True)
+
+    _observable_traits = List(["value"])
 
     def __init__(
         self,

--- a/ipytone/core.py
+++ b/ipytone/core.py
@@ -2,16 +2,10 @@ import math
 
 import numpy as np
 from ipywidgets import Widget, widget_serialization
-from traitlets import Bool, Dict, Enum, Float, Instance, Int, List, Tuple, Unicode, Union
+from traitlets import Bool, Dict, Enum, Float, Instance, Int, Unicode, Union
 from traittypes import Array
 
-from .base import (
-    AudioNode,
-    NativeAudioNode,
-    NativeAudioParam,
-    NodeWithContext,
-    ToneObject,
-)
+from .base import AudioNode, NativeAudioNode, NativeAudioParam, NodeWithContext, ToneObject
 from .callback import add_or_send_event
 from .observe import ScheduleObserveMixin
 from .serialization import data_array_serialization

--- a/ipytone/core.py
+++ b/ipytone/core.py
@@ -1,13 +1,19 @@
 import math
-import uuid
 
 import numpy as np
 from ipywidgets import Widget, widget_serialization
-from traitlets import Bool, Dict, Enum, Float, Instance, Int, List, Unicode, Union
+from traitlets import Bool, Dict, Enum, Float, Instance, Int, List, Tuple, Unicode, Union
 from traittypes import Array
 
-from .base import AudioNode, NativeAudioNode, NativeAudioParam, NodeWithContext, ToneObject
+from .base import (
+    AudioNode,
+    NativeAudioNode,
+    NativeAudioParam,
+    NodeWithContext,
+    ToneObject,
+)
 from .callback import add_or_send_event
+from .observe import ScheduleObserveMixin
 from .serialization import data_array_serialization
 
 UNITS = [
@@ -57,66 +63,6 @@ class InternalAudioNode(AudioNode):
     def _repr_keys(self):
         if self.type:
             yield "type"
-
-
-class ScheduleObserveMixin(Widget):
-    """Adds the ability to observe from within Python the current value of
-    a Parameter / Signal or Meter node.
-
-    The ``current_value`` (read-only) trait is used so that it does not interfer
-    with the ``value`` trait of the Parameter / Signal, which can be set from the
-    Python side.
-
-    TODO: only one observed handler should be allowed. Multiple handlers could be
-    associated with updates of ``current_value`` at different intervals but they
-    will all be called at every update of ``current_value``, which makes not much
-    sense.
-
-    """
-
-    current_value = Union(
-        (Float(), Int(), Unicode()), help="Param / Signal / Meter current value", read_only=True
-    ).tag(sync=True)
-
-    def schedule_observe(self, handler, repeat_interval=1, transport=False):
-        """Setup a handler to be called at regular intervals with the updated
-        ``current_value`` trait of this param / signal / meter node.
-
-        Parameters
-        ----------
-        handler : callable
-            A callable that is called when the ``current_value`` trait is updated at
-            regular intervals. The signature of the callable is similar
-            to the signature expected by :func:`ipywidgets.Widget.observe`.
-            Note that the handler will only apply to the ``current_value`` trait.
-        repeat_interval : float or string, optional
-            The interval at which the ``current_value`` trait is updated in the front-end,
-            in seconds (default: 1). If ``transport=True``, any interval accepted by
-            :func:`~ipytone.transport.schedule_repeat` is also valid here.
-        transport : bool, optional
-            if True, the value update is scheduled on the :class:`ipytone.Transport`
-            timeline, i.e., the handler is not called until the transport starts and
-            will stop being called when the transport stops. If False (default),
-            the value update is done in real-time.
-
-        """
-        data = {
-            "event": "scheduleObserve",
-            "repeat_interval": repeat_interval,
-            "transport": transport,
-            "hash_handler": hash(handler),
-        }
-        self.send(data)
-
-        self.observe(handler, names="current_value")
-
-    def schedule_unobserve(self, handler):
-        """Cancel the scheduled updates of the ``current_value`` trait associated
-        with the given handler.
-
-        """
-        self.send({"event": "scheduleUnobserve", "hash_handler": hash(handler)})
-        self.unobserve(handler, names="current_value")
 
 
 class ParamScheduleMixin:

--- a/ipytone/envelope.py
+++ b/ipytone/envelope.py
@@ -4,6 +4,7 @@ from traittypes import Array
 from .base import AudioNode
 from .callback import add_or_send_event
 from .core import Gain
+from .observe import ScheduleObserveMixin
 from .serialization import data_array_serialization
 from .signal import Pow, Scale, Signal
 
@@ -11,7 +12,7 @@ BASIC_CURVES = ["linear", "exponential"]
 CURVES = BASIC_CURVES + ["sine", "cosine", "bounce", "ripple", "step"]
 
 
-class Envelope(AudioNode):
+class Envelope(AudioNode, ScheduleObserveMixin):
     """ADSR envelope generator.
 
     Envelope outputs a signal which can be connected to a :class:`Signal`.

--- a/ipytone/envelope.py
+++ b/ipytone/envelope.py
@@ -36,6 +36,8 @@ class Envelope(AudioNode, ScheduleObserveMixin):
     array_length = Int(1024, help="Envelope data resolution (array length)").tag(sync=True)
     sync_array = Bool(False, help="If True, synchronize envelope data").tag(sync=True)
 
+    _observable_traits = List(["value"])
+
     def __init__(self, **kwargs):
         if "_output" not in kwargs:
             out_node = Signal(units="normalRange", _create_node=False)

--- a/ipytone/event.py
+++ b/ipytone/event.py
@@ -10,13 +10,14 @@ from .callback import (
     add_or_send_event,
     collect_and_merge_items,
 )
+from .observe import ScheduleObserveMixin
 
 
 def _no_callback(time, value=None):
     pass
 
 
-class Event(NodeWithContext):
+class Event(NodeWithContext, ScheduleObserveMixin):
     """Represents a single or repeatable event along the transport timeline.
 
     It abstracts away :func:`ipytone.transport.schedule`.
@@ -49,6 +50,9 @@ class Event(NodeWithContext):
     loop_end = Union(
         (Float(), Unicode()), default_value="1m", help="loop ending (transport) time"
     ).tag(sync=True)
+
+    _observable_traits = List(["state", "progress"])
+    _default_observed_trait = "state"
 
     def __init__(self, callback=None, value=None, **kwargs):
         if callback is None:

--- a/ipytone/observe.py
+++ b/ipytone/observe.py
@@ -14,7 +14,7 @@ class ToneDirectionalLink:
         self.observer.schedule_cancel()
 
 
-VALID_OBSERVED_TRAITS = ["time", "value", "state"]
+VALID_OBSERVED_TRAITS = ["time", "value", "state", "progress"]
 
 
 class ScheduleObserver(ToneWidgetBase):
@@ -54,6 +54,8 @@ class ScheduleObserver(ToneWidgetBase):
         help="current playback state",
         read_only=True,
     ).tag(sync=True)
+
+    progress = Float(0.0, help="current progress (loop intervals)").tag(sync=True)
 
     time_value = Tuple(
         Float(),
@@ -100,9 +102,9 @@ class ScheduleObserver(ToneWidgetBase):
         self.schedule_repeat(update_interval, transport, draw=draw)
 
         if js:
-            link = jsdlink((self, "value"), target)
+            link = jsdlink((self, self.observed_trait), target)
         else:
-            link = dlink((self, "value"), target)
+            link = dlink((self, self.observed_trait), target)
 
         return ToneDirectionalLink(self, link)
 

--- a/ipytone/observe.py
+++ b/ipytone/observe.py
@@ -1,4 +1,5 @@
-from ipywidgets import Widget, dlink, jsdlink, widget_serialization
+import ipywidgets
+from ipywidgets import widget_serialization
 from traitlets import Bool, Dict, Enum, Float, HasTraits, Instance, Int, List, Tuple, Unicode, Union
 
 from .base import ToneObject, ToneWidgetBase
@@ -40,11 +41,12 @@ class ScheduleObserver(ToneWidgetBase):
         sync=True
     )
 
-    time = Float(help="current observed time", read_only=True).tag(sync=True)
+    time = Float(0.0, help="current observed time", read_only=True).tag(sync=True)
 
     value = Union(
         (Float(), Int(), Unicode()),
         help="Param / Signal / Meter current observed value",
+        default_value=0,
         read_only=True,
     ).tag(sync=True)
 
@@ -55,7 +57,7 @@ class ScheduleObserver(ToneWidgetBase):
         read_only=True,
     ).tag(sync=True)
 
-    progress = Float(0.0, help="current progress (loop intervals)").tag(sync=True)
+    progress = Float(0.0, help="current progress (loop intervals)", read_only=True).tag(sync=True)
 
     position = Unicode(
         "0:0:0", help="current transport position in Bars:Beats:Sixteenths", read_only=True
@@ -112,9 +114,9 @@ class ScheduleObserver(ToneWidgetBase):
         self.schedule_repeat(update_interval, transport, draw=draw)
 
         if js:
-            link = jsdlink((self, self.observed_trait), target)
+            link = ipywidgets.jsdlink((self, self.observed_trait), target)
         else:
-            link = dlink((self, self.observed_trait), target)
+            link = ipywidgets.dlink((self, self.observed_trait), target)
 
         return ToneDirectionalLink(self, link)
 
@@ -235,13 +237,6 @@ class ScheduleObserveMixin(HasTraits):
         self._remove_observer(key)
 
     def _schedule_dlink(self, target, update_interval, transport, name, js=False):
-        widget, trait = target
-
-        if not isinstance(widget, Widget):
-            raise ValueError("the first item of target must be a Widget instance")
-        if not hasattr(widget, trait):
-            raise ValueError(f"{trait!r} is not a trait of widget {widget!r}")
-
         name = self._validate_trait_name(name)
 
         observer = ScheduleObserver(observed_widget=self, observed_trait=name)

--- a/ipytone/observe.py
+++ b/ipytone/observe.py
@@ -122,14 +122,18 @@ class ScheduleObserver(ToneWidgetBase):
 
 
 class ScheduleObserveMixin(HasTraits):
-    """Adds the ability to observe from within Python or the current value
-    of an attribute of an ipytone widget (e.g., Param, Signal, Envelope, Meter, etc.),
+    """Adds the ability to observe from within Python the current value of an
+    attribute of an ipytone widget (e.g., Param, Signal, Envelope, Meter, etc.)
     or link it with another widget attribute.
 
-    It is similar to ipywidgets's ``observe``, ``dlink`` and ``jsdlink``, but adds
-    the ability to observe or link ipytone widget attributes that may be updated
-    continuously in the front-end (e.g., value of an audio signal or an envelope,
-    position of the transport timeline, etc.).
+    It is similar to ipywidgets's ``observe``, ``dlink`` and ``jsdlink``, with
+    the extra ability here to observe or link ipytone widget attributes that may
+    be updated continuously in the front-end (e.g., value of an audio signal or
+    an envelope, position of the transport timeline, etc.).
+
+    The values of those ipytone widget attributes are sampled at given, regular
+    intervals, either along Tone.js' main transport timeline or with respect to
+    the active audio context.
 
     """
 

--- a/ipytone/observe.py
+++ b/ipytone/observe.py
@@ -1,0 +1,121 @@
+from ipywidgets import widget_serialization
+from traitlets import Dict, Enum, Float, HasTraits, Instance, Int, Tuple, Unicode, Union
+
+from .base import NodeWithContext, ToneWidgetBase
+
+
+class ScheduleObserver(ToneWidgetBase):
+    """Used internally to observe the current time and/or value of a Tone.js
+    Param / Signal / Meter instance at a given, regular interval.
+
+    Implementing this in a separate widget is more composable. It allows setting
+    multiple handlers on the same observed instance, possibly with different
+    update intervals. It also prevents any interference with the observed
+    Param / Signal ``value`` trait, which can be set from within Python.
+
+    """
+
+    _model_name = Unicode("ScheduleObserverModel").tag(sync=True)
+
+    observed_widget = Instance(
+        NodeWithContext,
+        help="observed Param / Signal / Meter widget",
+    ).tag(sync=True, **widget_serialization)
+
+    observed_trait = Enum(["time", "value", "time_value"], default_value="value").tag(sync=True)
+
+    time = Float(help="current observed time", read_only=True).tag(sync=True)
+
+    value = Union(
+        (Float(), Int(), Unicode()),
+        help="Param / Signal / Meter current observed value",
+        read_only=True,
+    ).tag(sync=True)
+
+    time_value = Tuple(
+        Float(),
+        Union((Float(), Int(), Unicode())),
+        help="Both current observed time and value",
+        allow_none=True,
+        read_only=True,
+    ).tag(sync=True)
+
+    def schedule_observe(self, handler, repeat_interval, transport):
+        data = {
+            "event": "scheduleObserve",
+            "repeat_interval": repeat_interval,
+            "transport": transport,
+        }
+        self.send(data)
+
+        self.observe(handler, names=self.observed_trait)
+
+    def schedule_unobserve(self, handler):
+        self.send({"event": "scheduleUnobserve"})
+        self.unobserve(handler, names=self.observed_trait)
+
+
+class ScheduleObserveMixin(HasTraits):
+    """Adds the ability to observe from within Python the current value
+    (and/or current time) of a Parameter / Signal or Meter node.
+
+    """
+
+    _observers = Dict(key_trait=Int(), value_trait=Instance(ScheduleObserver))
+
+    def schedule_observe(self, handler, repeat_interval=1, transport=False, name="value"):
+        """Setup a handler to be called at regular intervals with the updated
+        time / value of this param / signal / meter node.
+
+        Parameters
+        ----------
+        handler : callable
+            A callable that is called when the time and/or value is updated at
+            regular intervals. The signature of the callable is similar
+            to the signature expected by :func:`ipywidgets.Widget.observe`.
+            Note that the handler will only apply to the trait given by the
+            ``name`` argument.
+        repeat_interval : float or string, optional
+            The interval at which the trait is updated in the front-end,
+            in seconds (default: 1). If ``transport=True``, any interval accepted by
+            :func:`~ipytone.transport.schedule_repeat` is also valid here.
+        transport : bool, optional
+            if True, the trait update is scheduled along the :class:`ipytone.Transport`
+            timeline, i.e., the handler is not called until the transport starts and
+            will stop being called when the transport stops. If False (default),
+            the trait update is done in the active context.
+        name : { "time", "value", "time_value" }
+            The name of the trait to observe.
+
+            - "value" (default): the current value of the param / signal / meter node.
+            - "time": the current time (either transport time or context time).
+            - "time_value": both time and value returned as a tuple.
+
+        """
+        key = hash(handler)
+
+        if key in self._observers:
+            raise ValueError(
+                "this handler is already used. Call 'schedule_unobserve' first if you "
+                "want to apply this handler on another interval."
+            )
+
+        observer = ScheduleObserver(observed_widget=self, observed_trait=name)
+        observer.schedule_observe(handler, repeat_interval, transport)
+
+        observers = self._observers.copy()
+        observers[key] = observer
+        self._observers = observers
+
+    def schedule_unobserve(self, handler):
+        """Cancel the scheduled updates of the time / value trait associated
+        with the given handler.
+
+        """
+        key = hash(handler)
+
+        observers = self._observers.copy()
+        observer = observers.pop(key)
+        observer.schedule_unobserve(handler)
+        observer.close()
+        self._observers = observers

--- a/ipytone/observe.py
+++ b/ipytone/observe.py
@@ -5,8 +5,8 @@ from .base import NodeWithContext, ToneWidgetBase
 
 
 class ScheduleObserver(ToneWidgetBase):
-    """Used internally to observe the current time and/or value of a Tone.js
-    Param / Signal / Meter instance at a given, regular interval.
+    """Used internally to observe from Python the current time and/or value of a
+    Tone.js instance at a given, regular interval.
 
     Implementing this in a separate widget is more composable. It allows setting
     multiple handlers on the same observed instance, possibly with different
@@ -57,7 +57,7 @@ class ScheduleObserver(ToneWidgetBase):
 
 class ScheduleObserveMixin(HasTraits):
     """Adds the ability to observe from within Python the current value
-    (and/or current time) of a Parameter / Signal or Meter node.
+    of an ipytone widget (e.g., Param, Signal, Envelope, Meter, etc.).
 
     """
 
@@ -65,7 +65,7 @@ class ScheduleObserveMixin(HasTraits):
 
     def schedule_observe(self, handler, repeat_interval=1, transport=False, name="value"):
         """Setup a handler to be called at regular intervals with the updated
-        time / value of this param / signal / meter node.
+        time / value of this ipytone widget.
 
         Parameters
         ----------
@@ -74,7 +74,7 @@ class ScheduleObserveMixin(HasTraits):
             regular intervals. The signature of the callable is similar
             to the signature expected by :func:`ipywidgets.Widget.observe`.
             Note that the handler will only apply to the trait given by the
-            ``name`` argument.
+            ``name`` argument here.
         repeat_interval : float or string, optional
             The interval at which the trait is updated in the front-end,
             in seconds (default: 1). If ``transport=True``, any interval accepted by
@@ -83,12 +83,12 @@ class ScheduleObserveMixin(HasTraits):
             if True, the trait update is scheduled along the :class:`ipytone.Transport`
             timeline, i.e., the handler is not called until the transport starts and
             will stop being called when the transport stops. If False (default),
-            the trait update is done in the active context.
+            the trait update is done with respect to the active audio context.
         name : { "time", "value", "time_value" }
-            The name of the trait to observe.
+            The name of the trait to observe. It accepts one of the following:
 
-            - "value" (default): the current value of the param / signal / meter node.
-            - "time": the current time (either transport time or context time).
+            - "value" (default): the current value of the Tone.js corresponding instance.
+            - "time": the current time (either transport time or audio context time).
             - "time_value": both time and value returned as a tuple.
 
         """
@@ -117,5 +117,6 @@ class ScheduleObserveMixin(HasTraits):
         observers = self._observers.copy()
         observer = observers.pop(key)
         observer.schedule_unobserve(handler)
-        observer.close()
+        # TODO: it this the cause of "no comm in channel included" error?
+        # observer.close()
         self._observers = observers

--- a/ipytone/observe.py
+++ b/ipytone/observe.py
@@ -50,11 +50,12 @@ class ScheduleObserver(ToneWidgetBase):
         read_only=True,
     ).tag(sync=True)
 
-    def schedule_repeat(self, update_interval, transport):
+    def schedule_repeat(self, update_interval, transport, draw=False):
         data = {
             "event": "scheduleRepeat",
             "update_interval": update_interval,
             "transport": transport,
+            "draw": draw,
         }
         self.send(data)
 
@@ -70,7 +71,15 @@ class ScheduleObserver(ToneWidgetBase):
         self.unobserve(handler, names=self.observed_trait)
 
     def schedule_dlink(self, target, update_interval, transport, js=False):
-        self.schedule_repeat(update_interval, transport)
+        if js and transport:
+            # use Tone.js Draw for better synchronization
+            # of sound and visuals
+            draw = True
+        else:
+            draw = False
+
+        self.schedule_repeat(update_interval, transport, draw=draw)
+
         if js:
             link = jsdlink((self, "value"), target)
         else:
@@ -189,7 +198,7 @@ class ScheduleObserveMixin(HasTraits):
         """
         return self._schedule_dlink(target, update_interval, transport, js=False)
 
-    def schedule_jsdlink(self, target, update_interval=0.04, transport=False):
+    def schedule_jsdlink(self, target, update_interval=0.08, transport=False):
         """Link this ipytone widget value with a target widget attribute.
 
         The link is created in the front-end and does not rely on a roundtrip

--- a/ipytone/signal.py
+++ b/ipytone/signal.py
@@ -3,6 +3,7 @@ from traitlets import Bool, Float, Instance, Int, Unicode, Union
 
 from .base import AudioNode, ToneObject
 from .core import Gain, InternalAudioNode, Param, ParamScheduleMixin
+from .observe import ScheduleObserveMixin
 
 
 class SignalOperator(AudioNode):
@@ -47,7 +48,7 @@ class SignalOperator(AudioNode):
         return self._create_simple_op_signal(Pow, value=value)
 
 
-class Signal(SignalOperator, ParamScheduleMixin):
+class Signal(SignalOperator, ParamScheduleMixin, ScheduleObserveMixin):
     """A node that defines a value that can be modulated or calculated
     at the audio sample-level accuracy.
 

--- a/ipytone/signal.py
+++ b/ipytone/signal.py
@@ -1,5 +1,5 @@
 from ipywidgets import widget_serialization
-from traitlets import Bool, Float, Instance, Int, Unicode, Union
+from traitlets import Bool, Float, Instance, Int, List, Unicode, Union
 
 from .base import AudioNode, ToneObject
 from .core import Gain, InternalAudioNode, Param, ParamScheduleMixin
@@ -80,6 +80,8 @@ class Signal(SignalOperator, ParamScheduleMixin, ScheduleObserveMixin):
     value = Union((Float(), Int(), Unicode()), help="Signal value").tag(sync=True)
 
     _side_signal_prop_name = None
+
+    _observable_traits = List(["value"])
 
     def __init__(self, value=0, units="number", min_value=None, max_value=None, **kwargs):
         if "_input" not in kwargs:

--- a/ipytone/source.py
+++ b/ipytone/source.py
@@ -7,18 +7,22 @@ from traittypes import Array
 from .base import AudioNode
 from .callback import add_or_send_event
 from .core import AudioBuffer, AudioBuffers, Param, Volume
+from .observe import ScheduleObserveMixin
 from .serialization import data_array_serialization
 from .signal import Multiply, Scale, Signal
 from .utils import OSC_TYPES, parse_osc_type
 
 
-class Source(AudioNode):
+class Source(AudioNode, ScheduleObserveMixin):
     """Audio source node."""
 
     _model_name = Unicode("SourceModel").tag(sync=True)
 
     mute = Bool(False, help="Mute source").tag(sync=True)
     _volume = Instance(Param).tag(sync=True, **widget_serialization)
+
+    _observable_traits = List(["state"])
+    _default_observed_trait = "state"
 
     def __init__(self, volume=0, mute=False, **kwargs):
         out_node = Volume(volume=volume, mute=mute, _create_node=False)

--- a/ipytone/tests/test_observe.py
+++ b/ipytone/tests/test_observe.py
@@ -1,0 +1,153 @@
+import ipywidgets
+import pytest
+from traitlets import Float, Int, Unicode, Union
+
+from ipytone.core import Param
+from ipytone.envelope import Envelope
+from ipytone.event import Event
+from ipytone.observe import VALID_OBSERVED_TRAITS, ScheduleObserver
+from ipytone.signal import Signal
+from ipytone.source import Source
+from ipytone.transport import Transport
+
+
+@pytest.fixture(params=[Param, Signal, Envelope, Event, Signal, Source, Transport])
+def widget(request):
+    widget_cls = request.param
+    yield widget_cls()
+
+
+@pytest.fixture(scope="module", params=VALID_OBSERVED_TRAITS)
+def trait_name(request):
+    yield request.param
+
+
+@pytest.fixture(scope="module")
+def handler():
+    def func(change):
+        print(change)
+
+    yield func
+
+
+@pytest.fixture(scope="module")
+def target_widget():
+    class Widget(ipywidgets.Widget):
+        value = Union((Int(), Float(), Unicode())).tag(sync=True)
+
+    yield Widget()
+
+
+def test_schedule_observe(widget, trait_name, handler):
+    key = hash(handler)
+
+    if trait_name not in widget._observable_traits and trait_name != "time":
+        with pytest.raises(ValueError, match="invalid observable trait name"):
+            widget.schedule_observe(handler, name=trait_name)
+    else:
+        # test observe
+        widget.schedule_observe(handler, name=trait_name)
+        assert key in widget._observers
+
+        observer = widget._observers[key]
+        assert observer.observed_widget is widget
+        assert observer.observed_trait == trait_name
+
+        # test observe already observed with same handler
+        with pytest.raises(ValueError, match="this handler is already used"):
+            widget.schedule_observe(handler, name=trait_name)
+
+        # test unobserve
+        widget.schedule_unobserve(handler)
+        assert key not in widget._observers
+
+
+def test_schedule_observe_default_trait(widget, handler):
+    key = hash(handler)
+    widget.schedule_observe(handler)
+    assert widget._observers[key].observed_trait == widget._default_observed_trait
+
+
+def test_schedule_dlink(widget, trait_name, target_widget, mocker):
+    if trait_name not in widget._observable_traits and trait_name != "time":
+        with pytest.raises(ValueError, match="invalid observable trait name"):
+            widget.schedule_dlink((target_widget, "value"), name=trait_name)
+    else:
+        for method in (widget.schedule_dlink, widget.schedule_jsdlink):
+            link = method((target_widget, "value"), name=trait_name)
+
+            assert link.observer.observed_widget is widget
+            assert link.observer.observed_trait == trait_name
+
+            # test unlink
+            mocker.patch.object(link.link, "unlink")
+            mocker.patch.object(link.observer, "schedule_cancel")
+            link.unlink()
+            link.link.unlink.assert_called_once()
+            link.observer.schedule_cancel.assert_called_once()
+
+
+def test_schedule_observer():
+    sig = Signal()
+    observer = ScheduleObserver(observed_widget=sig)
+
+    assert observer.observed_widget is sig
+    assert observer.observe_time is False
+    assert observer.time == 0.0
+    assert observer.value == 0
+    assert observer.state == "stopped"
+    assert observer.progress == 0.0
+    assert observer.position == "0:0:0"
+    assert observer.ticks == 0
+    assert observer.seconds == 0.0
+    assert observer.time_value is None
+
+
+def test_schedule_observer_schedule_observe(mocker, handler):
+    sig = Signal()
+    observer = ScheduleObserver(observed_widget=sig)
+
+    mocker.patch.object(observer, "observe")
+    mocker.patch.object(observer, "unobserve")
+    mocker.patch.object(observer, "send")
+
+    observer.schedule_observe(handler, 1, True)
+    observer.observe.assert_called_with(handler, names="value")
+    observer.send.assert_called_with(
+        {"event": "scheduleRepeat", "update_interval": 1, "transport": True, "draw": False}
+    )
+
+    observer.schedule_unobserve(handler)
+    observer.unobserve.assert_called_with(handler, names="value")
+    observer.send.assert_called_with({"event": "scheduleCancel"})
+
+    # test observe time
+    observer.observe_time = True
+    observer.schedule_observe(handler, 1, True)
+    observer.observe.assert_called_with(handler, names="time_value")
+    observer.schedule_unobserve(handler)
+    observer.unobserve.assert_called_with(handler, names="time_value")
+
+
+def test_schedule_observer_schedule_link(mocker, target_widget):
+    dlink_patch = mocker.patch("ipywidgets.dlink")
+    jsdlink_patch = mocker.patch("ipywidgets.jsdlink")
+
+    sig = Signal()
+    observer = ScheduleObserver(observed_widget=sig)
+
+    mocker.patch.object(observer, "send")
+
+    # dlink
+    observer.schedule_dlink((target_widget, "value"), 1, True)
+    observer.send.assert_called_with(
+        {"event": "scheduleRepeat", "update_interval": 1, "transport": True, "draw": False}
+    )
+    dlink_patch.assert_called_with((observer, "value"), (target_widget, "value"))
+
+    # jsdlink
+    observer.schedule_dlink((target_widget, "value"), 1, True, js=True)
+    observer.send.assert_called_with(
+        {"event": "scheduleRepeat", "update_interval": 1, "transport": True, "draw": True}
+    )
+    jsdlink_patch.assert_called_with((observer, "value"), (target_widget, "value"))

--- a/ipytone/transport.py
+++ b/ipytone/transport.py
@@ -6,10 +6,11 @@ from traitlets import Bool, Float, Instance, Int, List, Unicode, Union
 from .base import ToneObject
 from .callback import TimeCallbackArg, add_or_send_event
 from .core import Param
+from .observe import ScheduleObserveMixin
 from .signal import Signal
 
 
-class Transport(ToneObject):
+class Transport(ToneObject, ScheduleObserveMixin):
     """Transport for timing musical events.
 
     Note: the transport position is not updated until changing the playback state
@@ -45,6 +46,9 @@ class Transport(ToneObject):
     seconds = Float(0, help="transport position in seconds").tag(sync=True)
     progress = Float(0, help="transport loop relative position", read_only=True).tag(sync=True)
     ticks = Int(0, help="transport position in ticks").tag(sync=True)
+
+    _observable_traits = List(["state", "progress", "position", "ticks", "seconds"])
+    _default_observed_trait = "state"
 
     def __new__(cls):
         if Transport._singleton is None:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { NodeWithContextModel } from './widget_base';
 
+import * as tone from 'tone';
+
 export type callbackArgs = { [key: string]: { eval: boolean; value: any } };
 
 export type callbackItem = {
@@ -10,6 +12,10 @@ export type callbackItem = {
   arg_keys: string[];
 };
 
+/*
+ * Replace null argument values by undefined so that it works well
+ * with Tone.js optional arguments.
+ */
 export function normalizeArguments(args: any, argsKeys: string[]): any[] {
   return argsKeys.map((name: string) => {
     if (args[name].value === null) {
@@ -18,4 +24,55 @@ export function normalizeArguments(args: any, argsKeys: string[]): any[] {
       return args[name].value;
     }
   });
+}
+
+export type ObserveEvent = {
+  id: number | ReturnType<typeof setInterval>;
+  transport: boolean;
+};
+
+export type ObserveEventMap = { [hash: number]: ObserveEvent };
+
+/*
+ * Used by ParamModel / SignalModel / (TODO: MeterModel) to
+ * schedule sync of `current_value` trait on regular intervals,
+ * either along tone.Transport's timeline or on the current context
+ * time.
+ */
+export function scheduleObserve(
+  obj: NodeWithContextModel,
+  transport: boolean,
+  repeatInterval: number | string
+): ObserveEvent {
+  let eid: number | ReturnType<typeof setInterval>;
+
+  if (transport) {
+    eid = tone.Transport.scheduleRepeat((time) => {
+      obj.set('current_value', obj.node.getValueAtTime(time));
+      obj.save_changes();
+    }, repeatInterval);
+  } else {
+    eid = setInterval(() => {
+      obj.set('current_value', obj.node.value);
+      obj.save_changes();
+    }, (repeatInterval as number) * 1000);
+  }
+
+  return { id: eid, transport: transport };
+}
+
+/*
+ * Cancel scheduled syncs created by `scheduleObserve`.
+ */
+export function scheduleUnobserve(
+  hashHandler: number,
+  eventMap: ObserveEventMap
+): void {
+  const event = eventMap[hashHandler];
+
+  if (event.transport) {
+    tone.Transport.cancel(event.id as number);
+  } else {
+    clearInterval(event.id as ReturnType<typeof setInterval>);
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
 import { NodeWithContextModel } from './widget_base';
 
+export function assert(statement: boolean, error: string): asserts statement {
+  if (!statement) {
+    throw new Error(error);
+  }
+}
+
 export type callbackArgs = { [key: string]: { eval: boolean; value: any } };
 
 export type callbackItem = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,5 @@
 import { NodeWithContextModel } from './widget_base';
 
-import * as tone from 'tone';
-
 export type callbackArgs = { [key: string]: { eval: boolean; value: any } };
 
 export type callbackItem = {
@@ -24,55 +22,4 @@ export function normalizeArguments(args: any, argsKeys: string[]): any[] {
       return args[name].value;
     }
   });
-}
-
-export type ObserveEvent = {
-  id: number | ReturnType<typeof setInterval>;
-  transport: boolean;
-};
-
-export type ObserveEventMap = { [hash: number]: ObserveEvent };
-
-/*
- * Used by ParamModel / SignalModel / (TODO: MeterModel) to
- * schedule sync of `current_value` trait on regular intervals,
- * either along tone.Transport's timeline or on the current context
- * time.
- */
-export function scheduleObserve(
-  obj: NodeWithContextModel,
-  transport: boolean,
-  repeatInterval: number | string
-): ObserveEvent {
-  let eid: number | ReturnType<typeof setInterval>;
-
-  if (transport) {
-    eid = tone.Transport.scheduleRepeat((time) => {
-      obj.set('current_value', obj.node.getValueAtTime(time));
-      obj.save_changes();
-    }, repeatInterval);
-  } else {
-    eid = setInterval(() => {
-      obj.set('current_value', obj.node.value);
-      obj.save_changes();
-    }, (repeatInterval as number) * 1000);
-  }
-
-  return { id: eid, transport: transport };
-}
-
-/*
- * Cancel scheduled syncs created by `scheduleObserve`.
- */
-export function scheduleUnobserve(
-  hashHandler: number,
-  eventMap: ObserveEventMap
-): void {
-  const event = eventMap[hashHandler];
-
-  if (event.transport) {
-    tone.Transport.cancel(event.id as number);
-  } else {
-    clearInterval(event.id as ReturnType<typeof setInterval>);
-  }
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -15,6 +15,7 @@ export * from './widget_envelope';
 export * from './widget_filter';
 export * from './widget_graph';
 export * from './widget_instrument';
+export { ScheduleObserverModel } from './widget_observe';
 export * from './widget_signal';
 export * from './widget_source';
 export * from './widget_transport';

--- a/src/widget_core.ts
+++ b/src/widget_core.ts
@@ -4,7 +4,7 @@ import * as tone from 'tone';
 
 import { UnitMap, UnitName } from 'tone/Tone/core/type/Units';
 
-import { normalizeArguments } from './utils';
+import { assert, normalizeArguments } from './utils';
 
 import { ObservableModel } from './widget_observe';
 
@@ -137,11 +137,13 @@ export class ParamModel<T extends UnitName>
     return opts;
   }
 
-  getValueAtTime(time: tone.Unit.Seconds): UnitMap[T] {
+  getValueAtTime(traitName: string, time: tone.Unit.Seconds): UnitMap[T] {
+    assert(traitName === 'value', 'param only supports "value" trait');
     return this.node.getValueAtTime(time);
   }
 
-  getValue(): UnitMap[T] {
+  getValue(traitName: string): UnitMap[T] {
+    assert(traitName === 'value', 'param only supports "value" trait');
     return this.node.value;
   }
 

--- a/src/widget_envelope.ts
+++ b/src/widget_envelope.ts
@@ -6,13 +6,15 @@ import { normalizeArguments } from './utils';
 
 import { AudioNodeModel } from './widget_base';
 
+import { ObservableModel } from './widget_observe';
+
 import {
   ArrayProperty,
   dataarray_serialization,
   getArrayProp,
 } from './serializers';
 
-export class EnvelopeModel extends AudioNodeModel {
+export class EnvelopeModel extends AudioNodeModel implements ObservableModel {
   defaults(): any {
     return {
       ...super.defaults(),
@@ -81,7 +83,15 @@ export class EnvelopeModel extends AudioNodeModel {
     this.maybeSetArray();
   }
 
-  private handleMsg(command: any, buffers: any): void {
+  getValueAtTime(time: tone.Unit.Seconds): tone.Unit.NormalRange {
+    return this.node.getValueAtTime(time);
+  }
+
+  getValue(): tone.Unit.NormalRange {
+    return this.node.value;
+  }
+
+  private handleMsg(command: any, _buffers: any): void {
     if (command.event === 'trigger') {
       const argsArray = normalizeArguments(command.args, command.arg_keys);
       (this.node as any)[command.method](...argsArray);

--- a/src/widget_envelope.ts
+++ b/src/widget_envelope.ts
@@ -2,7 +2,7 @@ import { ISerializers } from '@jupyter-widgets/base';
 
 import * as tone from 'tone';
 
-import { normalizeArguments } from './utils';
+import { assert, normalizeArguments } from './utils';
 
 import { AudioNodeModel } from './widget_base';
 
@@ -83,11 +83,16 @@ export class EnvelopeModel extends AudioNodeModel implements ObservableModel {
     this.maybeSetArray();
   }
 
-  getValueAtTime(time: tone.Unit.Seconds): tone.Unit.NormalRange {
+  getValueAtTime(
+    traitName: string,
+    time: tone.Unit.Seconds
+  ): tone.Unit.NormalRange {
+    assert(traitName === 'value', 'envelope only supports "value" trait');
     return this.node.getValueAtTime(time);
   }
 
-  getValue(): tone.Unit.NormalRange {
+  getValue(traitName: string): tone.Unit.NormalRange {
+    assert(traitName === 'value', 'envelope only supports "value" trait');
     return this.node.value;
   }
 

--- a/src/widget_event.ts
+++ b/src/widget_event.ts
@@ -5,6 +5,7 @@ import type { callbackArgs, callbackItem } from './utils';
 import { normalizeArguments } from './utils';
 
 import { NodeWithContextModel } from './widget_base';
+import { ObservableModel } from './widget_observe';
 
 type eventCallback = { (time: number, value: any): void };
 
@@ -22,7 +23,10 @@ interface Event {
   toFrequency: (frequency: tone.Unit.Frequency) => tone.Unit.Hertz;
 }
 
-abstract class BaseEventModel<T extends Event> extends NodeWithContextModel {
+abstract class BaseEventModel<T extends Event>
+  extends NodeWithContextModel
+  implements ObservableModel
+{
   defaults(): any {
     return {
       ...super.defaults(),
@@ -93,6 +97,23 @@ abstract class BaseEventModel<T extends Event> extends NodeWithContextModel {
   private async setCallback(command: any): Promise<void> {
     const items = await this.getCallbackItems(command.items);
     this.event.callback = this.getToneCallback(items);
+  }
+
+  getValueAtTime(
+    traitName: string,
+    _time: tone.Unit.Seconds
+  ): tone.BasicPlaybackState | tone.Unit.NormalRange {
+    return this.getValue(traitName);
+  }
+
+  getValue(traitName: string): tone.BasicPlaybackState | tone.Unit.NormalRange {
+    if (traitName === 'state') {
+      return (this.event as unknown as tone.ToneEvent).state;
+    } else if (traitName === 'progress') {
+      return (this.event as unknown as tone.ToneEvent).progress;
+    } else {
+      throw new Error('unsupported trait name ' + traitName);
+    }
   }
 
   private play(command: any): void {

--- a/src/widget_observe.ts
+++ b/src/widget_observe.ts
@@ -1,0 +1,116 @@
+import { ISerializers, unpack_models } from '@jupyter-widgets/base';
+
+import * as tone from 'tone';
+
+import { ToneWidgetModel } from './widget_base';
+
+type ObserveEvent = {
+  id: number | ReturnType<typeof setInterval>;
+  transport: boolean;
+};
+
+type ScheduleObserverCommand = {
+  event: string;
+  transport: boolean;
+  repeat_interval: string | number;
+};
+
+export interface ObservableModel {
+  getValueAtTime: (time: tone.Unit.Seconds) => tone.Unit.Unit;
+  getValue: () => tone.Unit.Unit;
+}
+
+export class ScheduleObserverModel extends ToneWidgetModel {
+  defaults(): any {
+    return {
+      ...super.defaults(),
+      _model_name: ScheduleObserverModel.model_name,
+      observed_widget: null,
+      observed_trait: 'value',
+      time: 0.0,
+      value: 0.0,
+      time_value: [],
+    };
+  }
+
+  private event: ObserveEvent;
+
+  initialize(
+    attributes: Backbone.ObjectHash,
+    options: { model_id: string; comm: any; widget_manager: any }
+  ): void {
+    super.initialize(attributes, options);
+
+    this.event = { id: 0, transport: false };
+  }
+
+  get observedWidget(): ObservableModel {
+    return this.get('observed_widget');
+  }
+
+  get observedTrait(): string {
+    return this.get('observed_trait');
+  }
+
+  private setObservedTrait(
+    time: tone.Unit.Seconds,
+    value: tone.Unit.Unit
+  ): void {
+    if (this.observedTrait === 'value') {
+      this.set('value', value);
+    } else if (this.observedTrait === 'time') {
+      this.set('time', time);
+    } else if (this.observedTrait === 'time_value') {
+      this.set('time_value', [time, value]);
+    }
+
+    this.save_changes();
+  }
+
+  private scheduleObserve(
+    transport: boolean,
+    repeatInterval: number | string
+  ): void {
+    const obj = this.observedWidget;
+    let eid: number | ReturnType<typeof setInterval>;
+
+    if (transport) {
+      eid = tone.Transport.scheduleRepeat((time) => {
+        this.setObservedTrait(time, obj.getValueAtTime(time));
+      }, repeatInterval);
+    } else {
+      eid = setInterval(() => {
+        this.setObservedTrait(tone.now(), obj.getValue());
+      }, (repeatInterval as number) * 1000);
+    }
+
+    this.event = { id: eid, transport: transport };
+  }
+
+  private scheduleUnobserve(): void {
+    if (this.event.transport) {
+      tone.Transport.cancel(this.event.id as number);
+    } else {
+      clearInterval(this.event.id as ReturnType<typeof setInterval>);
+    }
+  }
+
+  private handleMsg(command: ScheduleObserverCommand, _buffers: any): void {
+    if (command.event === 'scheduleObserve') {
+      this.scheduleObserve(command.transport, command.repeat_interval);
+    } else if (command.event === 'scheduleUnobserve') {
+      this.scheduleUnobserve();
+    }
+  }
+
+  initEventListeners(): void {
+    this.on('msg:custom', this.handleMsg, this);
+  }
+
+  static serializers: ISerializers = {
+    ...ToneWidgetModel.serializers,
+    observed_widget: { deserialize: unpack_models as any },
+  };
+
+  static model_name = 'ScheduleObserverModel';
+}

--- a/src/widget_observe.ts
+++ b/src/widget_observe.ts
@@ -33,8 +33,9 @@ export class ScheduleObserverModel extends ToneWidgetModel {
       observe_time: false,
       time: 0.0,
       value: 0.0,
-      time_value: [],
       state: 'stopped',
+      progress: 0.0,
+      time_value: [],
     };
   }
 

--- a/src/widget_observe.ts
+++ b/src/widget_observe.ts
@@ -12,7 +12,7 @@ type ObserveEvent = {
 type ScheduleObserverCommand = {
   event: string;
   transport: boolean;
-  repeat_interval: string | number;
+  update_interval: string | number;
 };
 
 export interface ObservableModel {
@@ -67,9 +67,9 @@ export class ScheduleObserverModel extends ToneWidgetModel {
     this.save_changes();
   }
 
-  private scheduleObserve(
+  private scheduleRepeat(
     transport: boolean,
-    repeatInterval: number | string
+    updateInterval: number | string
   ): void {
     const model = this.observedWidget;
     let eid: number | ReturnType<typeof setInterval>;
@@ -77,17 +77,17 @@ export class ScheduleObserverModel extends ToneWidgetModel {
     if (transport) {
       eid = tone.Transport.scheduleRepeat((time) => {
         this.setObservedTrait(time, model.getValueAtTime(time));
-      }, repeatInterval);
+      }, updateInterval);
     } else {
       eid = setInterval(() => {
         this.setObservedTrait(tone.now(), model.getValue());
-      }, (repeatInterval as number) * 1000);
+      }, (updateInterval as number) * 1000);
     }
 
     this.event = { id: eid, transport: transport };
   }
 
-  private scheduleUnobserve(): void {
+  private scheduleCancel(): void {
     if (this.event.transport) {
       tone.Transport.cancel(this.event.id as number);
     } else {
@@ -96,10 +96,10 @@ export class ScheduleObserverModel extends ToneWidgetModel {
   }
 
   private handleMsg(command: ScheduleObserverCommand, _buffers: any): void {
-    if (command.event === 'scheduleObserve') {
-      this.scheduleObserve(command.transport, command.repeat_interval);
-    } else if (command.event === 'scheduleUnobserve') {
-      this.scheduleUnobserve();
+    if (command.event === 'scheduleRepeat') {
+      this.scheduleRepeat(command.transport, command.update_interval);
+    } else if (command.event === 'scheduleCancel') {
+      this.scheduleCancel();
     }
   }
 

--- a/src/widget_observe.ts
+++ b/src/widget_observe.ts
@@ -71,16 +71,16 @@ export class ScheduleObserverModel extends ToneWidgetModel {
     transport: boolean,
     repeatInterval: number | string
   ): void {
-    const obj = this.observedWidget;
+    const model = this.observedWidget;
     let eid: number | ReturnType<typeof setInterval>;
 
     if (transport) {
       eid = tone.Transport.scheduleRepeat((time) => {
-        this.setObservedTrait(time, obj.getValueAtTime(time));
+        this.setObservedTrait(time, model.getValueAtTime(time));
       }, repeatInterval);
     } else {
       eid = setInterval(() => {
-        this.setObservedTrait(tone.now(), obj.getValue());
+        this.setObservedTrait(tone.now(), model.getValue());
       }, (repeatInterval as number) * 1000);
     }
 

--- a/src/widget_signal.ts
+++ b/src/widget_signal.ts
@@ -10,6 +10,8 @@ import { AudioNodeModel } from './widget_base';
 
 import { ParamModel } from './widget_core';
 
+import { ObservableModel } from './widget_observe';
+
 abstract class SignalOperatorModel extends AudioNodeModel {
   defaults(): any {
     return {
@@ -21,7 +23,10 @@ abstract class SignalOperatorModel extends AudioNodeModel {
   static model_name = 'SignalOperatorModel';
 }
 
-export class SignalModel<T extends UnitName> extends SignalOperatorModel {
+export class SignalModel<T extends UnitName>
+  extends SignalOperatorModel
+  implements ObservableModel
+{
   defaults(): any {
     return {
       ...super.defaults(),
@@ -65,6 +70,14 @@ export class SignalModel<T extends UnitName> extends SignalOperatorModel {
   connectInputCallback(): void {
     // new connected incoming signal overrides this signal value
     this.updateOverridden();
+  }
+
+  getValueAtTime(time: tone.Unit.Seconds): UnitMap[T] {
+    return this.node.getValueAtTime(time);
+  }
+
+  getValue(): UnitMap[T] {
+    return this.node.value;
   }
 
   private handleMsg(command: any, buffers: any): void {

--- a/src/widget_signal.ts
+++ b/src/widget_signal.ts
@@ -4,7 +4,7 @@ import * as tone from 'tone';
 
 import { UnitName, UnitMap } from 'tone/Tone/core/type/Units';
 
-import { normalizeArguments } from './utils';
+import { assert, normalizeArguments } from './utils';
 
 import { AudioNodeModel } from './widget_base';
 
@@ -72,15 +72,17 @@ export class SignalModel<T extends UnitName>
     this.updateOverridden();
   }
 
-  getValueAtTime(time: tone.Unit.Seconds): UnitMap[T] {
+  getValueAtTime(traitName: string, time: tone.Unit.Seconds): UnitMap[T] {
+    assert(traitName === 'value', 'param only supports "value" trait');
     return this.node.getValueAtTime(time);
   }
 
-  getValue(): UnitMap[T] {
+  getValue(traitName: string): UnitMap[T] {
+    assert(traitName === 'value', 'param only supports "value" trait');
     return this.node.value;
   }
 
-  private handleMsg(command: any, buffers: any): void {
+  private handleMsg(command: any, _buffers: any): void {
     if (command.event === 'trigger') {
       const argsArray = normalizeArguments(command.args, command.arg_keys);
       (this.node as any)[command.method](...argsArray);

--- a/src/widget_transport.ts
+++ b/src/widget_transport.ts
@@ -10,11 +10,13 @@ import { NodeWithContextModel, ToneObjectModel } from './widget_base';
 
 import { ParamModel } from './widget_core';
 
+import { ObservableModel } from './widget_observe';
+
 import { SignalModel } from './widget_signal';
 
 type transportCallback = { (time: number): void };
 
-export class TransportModel extends ToneObjectModel {
+export class TransportModel extends ToneObjectModel implements ObservableModel {
   defaults(): any {
     return {
       ...super.defaults(),
@@ -64,6 +66,34 @@ export class TransportModel extends ToneObjectModel {
     });
 
     return Promise.all(itemsModel);
+  }
+
+  getValueAtTime(traitName: string, time: tone.Unit.Seconds): tone.Unit.Unit {
+    switch (traitName) {
+      case 'ticks':
+        return tone.Transport.getTicksAtTime(time);
+      case 'seconds':
+        return tone.Transport.getSecondsAtTime(time);
+      default:
+        return this.getValue(traitName);
+    }
+  }
+
+  getValue(traitName: string): tone.Unit.Unit {
+    switch (traitName) {
+      case 'ticks':
+        return tone.Transport.ticks;
+      case 'seconds':
+        return tone.Transport.seconds;
+      case 'progress':
+        return tone.Transport.progress;
+      case 'position':
+        return tone.Transport.position;
+      case 'state':
+        return tone.Transport.state;
+      default:
+        throw new Error('unsupported trait name ' + traitName);
+    }
   }
 
   private getToneCallback(items: callbackItem[]): transportCallback {


### PR DESCRIPTION
Implements some ideas in #30 and #42.

TODO: 

- [x] add observe support for transport traits (state, position, seconds, ticks, progress, ppq...)
- [x] add tests
- schedule observe by passing an event as an alternative to `update_interval`? (maybe later)