### PR TITLE
Add `trigger_note()` method

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,9 @@ Enhancements
 - Added :py:class:`WaveShaper` signal node operator (:pull:`100`).
 - Added :py:class:`PitchShift` effect node (:pull:`101`).
 - Added :py:class:`FrequencyShifter` effect node (:pull:`102`).
+- Added :py:meth:`Instrument.trigger_note` method that helps conditional
+  scheduling of attack or release events within :py:class:`Part` callbacks.
+  :py:class:`Note` has also a new ``trigger_type`` attribute (:pull:`105`).
 
 Bug fixes
 ~~~~~~~~~

--- a/ipytone/callback.py
+++ b/ipytone/callback.py
@@ -83,6 +83,7 @@ class EventValueCallbackArg(BaseCallbackArg):
     - note
     - velocicty
     - duration (value must be in seconds)
+    - trigger_type
 
     """
 
@@ -100,6 +101,10 @@ class EventValueCallbackArg(BaseCallbackArg):
     @property
     def duration(self):
         return self.derive(str(self.value) + ".duration")
+
+    @property
+    def trigger_type(self):
+        return self.derive(str(self.value) + ".trigger_type")
 
 
 def add_or_send_event(method, callee, args, event="trigger"):

--- a/ipytone/event.py
+++ b/ipytone/event.py
@@ -122,22 +122,48 @@ class Event(NodeWithContext, ScheduleObserveMixin):
             yield "loop_end"
 
 
+TRIGGER_TYPES = ("attack", "release", "attack_release")
+
+
 class Note:
     """A single note with time, note (frequency) and velocity values.
 
-    This is useful for directly calling a :class:`ipytone.Part` callback
-    with multiple notes (unlike Tone.js, every note passed as value to the
-    callback must have a defined structure, i.e., no arbitrary attributes).
+    This is just a placeholder for some attributes that allows a little more
+    flexibility in :class:`ipytone.Part`. Unlike in Tone.js, it is not possible
+    to pass arbitrary objects as the 2nd argument of a ``Part`` callback.
+    Instead, every ``Part`` event is coerced to a ``Note`` object that can be
+    passed directly to :py:meth:`Instrument.trigger_note` or to other trigger
+    methods (using its attributes) inside the callback body.
 
-    Note: duration units is seconds.
+    Attributes
+    ----------
+    time : float or str
+        The relative partition time when the note should be triggered.
+    note : float or str
+        The actual note or frequency.
+    velocity : float, optional
+        The note velocity (in general any value between 0 and 1).
+    duration : float, optional
+        The note duration in seconds (generaly used with the
+        "attack_release" trigger type).
+    trigger_type : {'attack', 'release', 'attack_release'}, optional
+        The type of event. Used in :py:meth:`Instrument.trigger_note`
+        to determine the action to perform.
 
     """
 
-    def __init__(self, time, note, velocity=1, duration=0.1):
+    def __init__(self, time, note, velocity=1, duration=0.1, trigger_type="attack_release"):
+        if trigger_type not in TRIGGER_TYPES:
+            raise ValueError(
+                "invalid trigger type, must be one of "
+                + ",".join([f"{t!r}" for t in TRIGGER_TYPES])
+            )
+
         self.time = time
         self.note = note
         self.velocity = velocity
         self.duration = duration
+        self.trigger_type = trigger_type
 
     def to_dict(self):
         return {
@@ -145,6 +171,7 @@ class Note:
             "note": self.note,
             "velocity": self.velocity,
             "duration": self.duration,
+            "trigger_type": self.trigger_type,
         }
 
 

--- a/ipytone/tests/test_event.py
+++ b/ipytone/tests/test_event.py
@@ -130,8 +130,20 @@ def test_part_callback(mocker):
     part.send.assert_called_with(expected)
 
     assert part._events == [
-        {"time": "0:0", "note": "C3", "velocity": 1, "duration": 0.1},
-        {"time": "0:2", "note": "D3", "velocity": 0.5, "duration": 0.1},
+        {
+            "time": "0:0",
+            "note": "C3",
+            "velocity": 1,
+            "duration": 0.1,
+            "trigger_type": "attack_release",
+        },
+        {
+            "time": "0:2",
+            "note": "D3",
+            "velocity": 0.5,
+            "duration": 0.1,
+            "trigger_type": "attack_release",
+        },
     ]
 
     with pytest.raises(ValueError, match="cannot interpret this value as a Note"):
@@ -148,7 +160,13 @@ def test_part_add(mocker, note):
 
     expected = {
         "event": "add",
-        "arg": {"time": "0:0", "note": "C3", "velocity": 1, "duration": 0.1},
+        "arg": {
+            "time": "0:0",
+            "note": "C3",
+            "velocity": 1,
+            "duration": 0.1,
+            "trigger_type": "attack_release",
+        },
     }
     part.send.assert_called_once_with(expected)
 
@@ -163,7 +181,13 @@ def test_part_at(mocker, note):
     expected = {
         "event": "at",
         "time": "0:0",
-        "value": {"time": "0:0", "note": "C3", "velocity": 1, "duration": 0.1},
+        "value": {
+            "time": "0:0",
+            "note": "C3",
+            "velocity": 1,
+            "duration": 0.1,
+            "trigger_type": "attack_release",
+        },
     }
     part.send.assert_called_once_with(expected)
 
@@ -178,7 +202,13 @@ def test_part_remove(mocker, note):
     expected = {
         "event": "remove",
         "time": "0:0",
-        "value": {"time": "0:0", "note": "C3", "velocity": 1, "duration": 0.1},
+        "value": {
+            "time": "0:0",
+            "note": "C3",
+            "velocity": 1,
+            "duration": 0.1,
+            "trigger_type": "attack_release",
+        },
     }
     part.send.assert_called_once_with(expected)
 

--- a/ipytone/tests/test_event.py
+++ b/ipytone/tests/test_event.py
@@ -89,6 +89,11 @@ def test_event_cancel(mocker, method):
     event.send.assert_called_once_with({"event": "cancel", "time": None})
 
 
+def test_note_error():
+    with pytest.raises(ValueError, match="invalid trigger type"):
+        Note(0, "C3", trigger_type="invalid")
+
+
 def test_part():
     part = Part()
     assert part.length == 0

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,15 +17,31 @@ export type callbackItem = {
 };
 
 /*
+ * Return an array of argument values from an object.
+ *
+ * Sort values according to a given array of argument names.
+ * Maybe skip some given elements.
+ *
  * Replace null argument values by undefined so that it works well
  * with Tone.js optional arguments.
  */
-export function normalizeArguments(args: any, argsKeys: string[]): any[] {
-  return argsKeys.map((name: string) => {
-    if (args[name].value === null) {
-      return undefined;
-    } else {
-      return args[name].value;
-    }
-  });
+export function normalizeArguments(
+  args: any,
+  argsKeys: string[],
+  skipArgs: string[] = [],
+): any[] {
+  return argsKeys
+    .filter((name: string) => {
+      if (skipArgs.includes(name)) {
+        return false;
+      }
+      return true;
+    })
+    .map((name: string) => {
+      if (args[name].value === null) {
+        return undefined;
+      } else {
+        return args[name].value;
+      }
+    });
 }


### PR DESCRIPTION
It allows scheduling ``trigger_attack`` and/or ``trigger_release`` events within ``Part`` callbacks with more ease.

This is needed, e.g., when note duration is not provided (as in MIDI files).

Closes #85.