### PR TITLE
Maintenance: use tbump for managing version number

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,3 +16,4 @@ dependencies:
   - build
   - twine
   - traittypes
+  - tbump

--- a/ipytone/__init__.py
+++ b/ipytone/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (c) Benoit Bovy.
 # Distributed under the terms of the Modified BSD License.
 
-from ._version import __version__, version_info
+from ._version import __version__
 from .analysis import FFT, Analyser, DCMeter, Follower, Meter, Waveform
 from .base import PyAudioNode
 from .channel import (

--- a/ipytone/_frontend.py
+++ b/ipytone/_frontend.py
@@ -7,5 +7,7 @@
 Information about the frontend package of the widgets.
 """
 
+from ._version import __version__
+
 module_name = "ipytone"
-module_version = "^0.5.1"
+module_version = f"^{__version__}"

--- a/ipytone/_version.py
+++ b/ipytone/_version.py
@@ -3,5 +3,4 @@
 # Copyright (c) Benoit Bovy.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 5, 1)
-__version__ = ".".join(map(str, version_info))
+__version__ = "0.5.1"

--- a/ipytone/tests/test_frontend.py
+++ b/ipytone/tests/test_frontend.py
@@ -1,0 +1,7 @@
+import ipytone
+from ipytone._frontend import module_name, module_version
+
+
+def test_frontend():
+    assert module_name == "ipytone"
+    assert module_version == f"^{ipytone.__version__}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,28 @@ known-third-party=[
     "ipywidgets",
     "traitlets",
 ]
+
+[tool.tbump]
+field = [
+    { name = "channel", default = "" },
+    { name = "release", default = "" },
+]
+
+[tool.tbump.git]
+message_template = "release {new_version}"
+tag_template = "{new_version}"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+version_template = "version = \"{major}.{minor}.{patch}{channel}{release}\""
+
+[[tool.tbump.file]]
+src = "ipytone/_version.py"
+
+[[tool.tbump.file]]
+src = "package.json"
+version_template = "\"version\": \"{major}.{minor}.{patch}{channel}{release}\""
+
+[tool.tbump.version]
+current = "0.5.1"
+regex = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<channel>a|b|rc|.dev)(?P<release>\\d+))?"


### PR DESCRIPTION
Hopefully a working tbump release will be published before the next ipytone release (https://github.com/your-tools/tbump/issues/156).